### PR TITLE
46 ggplot2 theme title and subtitle size

### DIFF
--- a/R/theme.R
+++ b/R/theme.R
@@ -13,13 +13,12 @@ theme_omni <- function(show_grid_lines = FALSE,
                        show_legend = FALSE,
                        base_family = "Calibri") {
   # general theme based on theme_minimal
-  omni_theme <- theme_minimal(base_family = base_family,
-                              base_size = 10) +
+  omni_theme <- theme_minimal(base_family = base_family) +
     theme(
       panel.grid.minor = element_blank(),
       axis.ticks = element_blank(),
-      axis.title.x = element_text(margin = margin(15, 0, 0, 0), color = "#595959"),
-      axis.title.y = element_text(margin = margin(0, 15, 0, 0), color = "#595959"),
+      axis.title.x = element_text(margin = margin(15, 0, 0, 0), size = 10, color = "#595959"),
+      axis.title.y = element_text(margin = margin(0, 15, 0, 0), size = 10, color = "#595959"),
       plot.title = element_markdown(
         margin = margin(0, 0, 15, 0),
         color = "#595959",

--- a/R/theme.R
+++ b/R/theme.R
@@ -10,22 +10,25 @@
 #' @importFrom ggplot2 theme_minimal theme element_blank element_text margin
 #' @importFrom ggtext element_markdown
 theme_omni <- function(show_grid_lines = FALSE,
-                       show_legend = TRUE,
+                       show_legend = FALSE,
                        base_family = "Calibri") {
   # general theme based on theme_minimal
-  omni_theme <- theme_minimal(base_family = base_family) +
+  omni_theme <- theme_minimal(base_family = base_family,
+                              base_size = 10) +
     theme(
       panel.grid.minor = element_blank(),
       axis.ticks = element_blank(),
-      axis.title.x = element_text(margin = margin(15, 0, 0, 0)),
-      axis.title.y = element_text(margin = margin(0, 15, 0, 0)),
+      axis.title.x = element_text(margin = margin(15, 0, 0, 0), color = "#595959"),
+      axis.title.y = element_text(margin = margin(0, 15, 0, 0), color = "#595959"),
       plot.title = element_markdown(
         margin = margin(0, 0, 15, 0),
+        color = "#595959",
         face = "bold",
         size = 12
       ),
-      plot.subtitle = element_markdown(size = 12),
-      plot.caption = element_text(size = 11, face = "italic")
+      plot.subtitle = element_markdown(size = 11, color = "#595959"),
+      plot.caption = element_text(size = 11, face = "italic"),
+      plot.margin = margin(t = 7, r = 7, b = 7, l = 7, unit = "points")
     )
 
   # grid lines option


### PR DESCRIPTION
Hi, Thomas! I updated a few things in the theme.R file so that things match the OMNI guidelines: issue #46 

- turned legend off by default
- made the subtitle smaller than the title (11pt)
- made the title, subtitle, and axis titles a dark grey
- made the axis titles 10 pt
- added a bit of margin around the plot (guidelines ask for sufficient space around plots)

Data labels (from geom_text) still look too large by default (should be same size as axis titles), and they are not calibri by default. Unsure if that's something we can set in a theme or if the user (but that's in mm).

```
> GeomText$default_aes
Aesthetic mapping: 
* `colour`     -> "black"
* `size`       -> 3.88
* `angle`      -> 0
* `hjust`      -> 0.5
* `vjust`      -> 0.5
* `alpha`      -> NA
* `family`     -> ""
* `fontface`   -> 1
* `lineheight` -> 1.2
```