### PR TITLE
Adjust default font sizes

### DIFF
--- a/R/ggplot_defaults.R
+++ b/R/ggplot_defaults.R
@@ -22,28 +22,28 @@ set_omni_defaults <- function(
     "text",
     list(
       family = base_family,
-      size = 4.22
+      size = 12 / .pt
     )
   )
   ggplot2::update_geom_defaults(
     "label",
     list(
       family = base_family,
-      size = 4.22
+      size = 12 / .pt
     )
   )
   ggplot2::update_geom_defaults(
     "text_repel",
     list(
       family = base_family,
-      size = 4.22
+      size = 12 / .pt
     )
   )
   ggplot2::update_geom_defaults(
     "label_repel",
     list(
       family = base_family,
-      size = 4.22
+      size = 12 / .pt
     )
   )
 
@@ -85,7 +85,6 @@ set_omni_defaults <- function(
   ggplot2::update_geom_defaults("step", list(linewidth = 1))
   ggplot2::update_geom_defaults("path", list(linewidth = 1))
   ggplot2::update_geom_defaults("point", list(size = 3))
-  ggplot2::update_geom_defaults("text", list(size = 1 / 0.352777778))
 }
 
 #' Resets to default setting


### PR DESCRIPTION
Closes #138 

This was a funny issue. Took me a bit to realize what's going on. The only real problem was that in the last line of `set_omni_defaults()` there was this line:

```r
ggplot2::update_geom_defaults("text", list(size = 1 / 0.352777778))
```

Thus, the size was always hard-coded to that. Regardless of what was changed in the code above that. 

Note that I created a new branch `new_ggplot_defaults` that I'm PR-ing into `rebrand` because the initial branch in PR #139 also had some changes in the `omni_theme()` function that are not appropriate in some places because we've already modified that function. If the settings of `omni_theme()` are already the way they are supposed to be, then we can just delete PR #139 and merge my new branch into `rebrand`.