### PR TITLE
Place acknowledgements automatically at bottom of front page

### DIFF
--- a/inst/assets/pdf_report.css
+++ b/inst/assets/pdf_report.css
@@ -234,9 +234,6 @@ li li .toc-section-number {
   font-family: var(--header-font);
 }
 
-.client-name {
-  margin-bottom: 325pt;
-}
 
 p.for-more-info,
 p.acknowledge,
@@ -247,9 +244,21 @@ p.suggested-citation {
   letter-spacing: 0.05em;
 }
 
+div.front-page {
+  display: flex;
+  height: -webkit-fill-available;
+}
+
 /* by default, abstracts have smaller width */
 div.abstract {
   width: 100% !important;
+  display: flex;
+  flex-direction: column;
+}
+
+div.end-of-abstract {
+  margin-top: auto;
+  margin-bottom: 1em;
 }
 
 /* remove the h3 title "Abstract" */

--- a/inst/rmarkdown/templates/report-pdf/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/report-pdf/skeleton/skeleton.Rmd
@@ -5,7 +5,7 @@ client_name: "[client]"
 client_city: "[city]"
 client_state: "[state]"
 report_year: "[year]"
-acknowledgements: "[...]"
+acknowledgements: "**[one name, and another name, and more names, and lots of names]**"
 date: "`r toupper(format(Sys.time(), '%B %Y'))`"
 toc-title: "Table of Contents"
 output:


### PR DESCRIPTION
Closes #179

This PR applies CSS style changes so that the acknowledgements are placed at the bottom of the front page automatically. That way, the next page stays empty as intended. Independent of the length of the acknowledgements, there's always the same amount of vertical space ("1em") between the "Suggested Citation" block and the horizontal line that follows it.

<img width="949" height="1384" alt="image" src="https://github.com/user-attachments/assets/d32896c6-c5cb-43db-a09f-82e11ca1530a" />

