### PR TITLE
Add label-gray and bar-gray; align plum-600 to color guidance

### DIFF
--- a/R/colors.R
+++ b/R/colors.R
@@ -6,7 +6,8 @@
 #' "orange-red-600", "golden-yellow-200", "golden-yellow-400", "golden-yellow-600",
 #' "olive-green-200", "olive-green-400", "olive-green-600", "teal-200", "teal-400",
 #' "teal-600", "plum-200", "plum-400", "plum-600", "periwinkle-200", "periwinkle-400",
-#' "periwinkle-600", "steel-blue-200", "steel-blue-400", "steel-blue-600"
+#' "periwinkle-600", "steel-blue-200", "steel-blue-400", "steel-blue-600", "navy",
+#' "label-gray", "bar-gray"
 #'
 #' @name omni_colors
 #' @param colors_sub Character vector of color names.
@@ -43,7 +44,9 @@ omni_colors <- function(
     "steel-blue-200",
     "steel-blue-400",
     "steel-blue-600",
-    "navy"
+    "navy",
+    "label-gray",
+    "bar-gray"
   ),
   named = FALSE
 ) {
@@ -72,7 +75,9 @@ omni_colors <- function(
     "steel-blue-200",
     "steel-blue-400",
     "steel-blue-600",
-    "navy"
+    "navy",
+    "label-gray",
+    "bar-gray"
   )
 
   wrong_colors <- colors_sub[!(colors_sub %in% allowed_colors)]
@@ -102,14 +107,16 @@ omni_colors <- function(
     `teal-600` = "#41816F",
     `plum-200` = "#DD9CB9",
     `plum-400` = "#C65A8B",
-    `plum-600` = "#821C4C",
+    `plum-600` = "#921C4C",
     `periwinkle-200` = "#D4DDEB",
     `periwinkle-400` = "#A9BAD8",
     `periwinkle-600` = "#5776B2",
     `steel-blue-200` = "#BFCBD3",
     `steel-blue-400` = "#677384",
     `steel-blue-600` = "#405065",
-    `navy` = "#081C39"
+    `navy` = "#081C39",
+    `label-gray` = "#6D6D6D",
+    `bar-gray` = "#7D7D7D"
   )
 
   output_colors <- omni_color_vector[colors_sub]

--- a/man/omni_colors.Rd
+++ b/man/omni_colors.Rd
@@ -9,7 +9,8 @@ omni_colors(
     "orange-red-600", "golden-yellow-200", "golden-yellow-400", "golden-yellow-600",
     "olive-green-200", "olive-green-400", "olive-green-600", "teal-200", "teal-400",
     "teal-600", "plum-200", "plum-400", "plum-600", "periwinkle-200", "periwinkle-400",
-    "periwinkle-600", "steel-blue-200", "steel-blue-400", "steel-blue-600", "navy"),
+    "periwinkle-600", "steel-blue-200", "steel-blue-400", "steel-blue-600", "navy",
+    "label-gray", "bar-gray"),
   named = FALSE
 )
 }
@@ -28,7 +29,8 @@ Choose from:
 "orange-red-600", "golden-yellow-200", "golden-yellow-400", "golden-yellow-600",
 "olive-green-200", "olive-green-400", "olive-green-600", "teal-200", "teal-400",
 "teal-600", "plum-200", "plum-400", "plum-600", "periwinkle-200", "periwinkle-400",
-"periwinkle-600", "steel-blue-200", "steel-blue-400", "steel-blue-600"
+"periwinkle-600", "steel-blue-200", "steel-blue-400", "steel-blue-600", "navy",
+"label-gray", "bar-gray"
 }
 \examples{
 omni_colors("orange-red-400")


### PR DESCRIPTION
Tier A of the 2026-05 color-guidance alignment.

- Add two structural neutral colors to omni_colors(): label-gray (#6D6D6D, all gray text) and bar-gray (#7D7D7D, non-highlighted fills). These also become available as marquee title tags via theme_omni().
- Correct plum-600 from #821C4C to #921C4C to match the final color guidance (and the package's own CSS, which already used #921C4C).

Backward compatible: only adds palette entries plus a 1-digit plum shift. The "600"-name filter in design_elements.R correctly excludes the new grays from box/callout colors.