### PR TITLE
theme_omni + defaults: chart-gray, not steel-blue / black

### DIFF
--- a/R/ggplot_defaults.R
+++ b/R/ggplot_defaults.R
@@ -10,7 +10,7 @@
 #' @export
 set_omni_defaults <- function(
   base_family = "Inter Tight",
-  base_color = "#405065"
+  base_color = omni_colors("chart-gray")
 ) {
   # set default theme -----------------------------------------------------
 
@@ -26,7 +26,7 @@ set_omni_defaults <- function(
     list(
       family = base_family,
       size = 12 / .pt,
-      color = "#595959",
+      color = omni_colors("chart-gray"),
       fontface = "bold"
     )
   )
@@ -35,7 +35,7 @@ set_omni_defaults <- function(
     list(
       family = base_family,
       size = 12 / .pt,
-      color = "#595959",
+      color = omni_colors("chart-gray"),
       fontface = "bold"
     )
   )
@@ -44,7 +44,7 @@ set_omni_defaults <- function(
     list(
       family = base_family,
       size = 12 / .pt,
-      color = "#595959",
+      color = omni_colors("chart-gray"),
       fontface = "bold"
     )
   )
@@ -53,7 +53,7 @@ set_omni_defaults <- function(
     list(
       family = base_family,
       size = 12 / .pt,
-      color = "#595959",
+      color = omni_colors("chart-gray"),
       fontface = "bold"
     )
   )

--- a/R/theme.R
+++ b/R/theme.R
@@ -53,14 +53,19 @@ theme_omni <- function(
       axis.title.x = element_text(
         margin = margin(15, 0, 0, 0),
         size = 14,
-        color = "#000000"
+        color = omni_colors("chart-gray")
       ),
       axis.title.y = element_text(
         margin = margin(0, 15, 0, 0),
         size = 12,
-        color = "#000000"
+        color = omni_colors("chart-gray")
       ),
-      axis.text = element_text(size = 12, color = "#000000"),
+      # element_markdown so omni_highlight_labels() colored spans render without a
+      # per-chart override; the position-specific slots are set too because ggplot
+      # resolves those (not the parent) for the drawn tick labels
+      axis.text = ggtext::element_markdown(size = 12, color = omni_colors("chart-gray")),
+      axis.text.x.bottom = ggtext::element_markdown(size = 12, color = omni_colors("chart-gray")),
+      axis.text.y.left = ggtext::element_markdown(size = 12, color = omni_colors("chart-gray")),
       plot.title = marquee::element_marquee(
         margin = margin(0, 0, 0, 0),
         color = "#666665",

--- a/man/set_omni_defaults.Rd
+++ b/man/set_omni_defaults.Rd
@@ -4,7 +4,10 @@
 \alias{set_omni_defaults}
 \title{Update defaults to OMNI's theme}
 \usage{
-set_omni_defaults(base_family = "Inter Tight", base_color = "#405065")
+set_omni_defaults(
+  base_family = "Inter Tight",
+  base_color = omni_colors("chart-gray")
+)
 }
 \arguments{
 \item{base_family}{The base font family for the theme.}


### PR DESCRIPTION
## Summary

Aligns the package's ggplot defaults with the current Omni data-viz guidance — non-highlighted chart elements and gray text should be **chart-gray `#767676`**, not steel-blue or black. Follow-up to #233 (which added the `chart-gray` named color).

**Changes:**
- **`set_omni_defaults()`** — `base_color` default `#405065` (steel-blue-600) → `omni_colors("chart-gray")`. A bare `geom_col()` / `geom_point()` / `geom_line()` (no fill/color mapping) now defaults to gray, matching "no highlight → everything gray." Also the `text` / `label` / `text_repel` / `label_repel` default color `#595959` → chart-gray.
- **`theme_omni()`** — axis text + axis titles `#000000` (black) → chart-gray. Axis text is now `ggtext::element_markdown` (with the position-specific `axis.text.x.bottom` / `axis.text.y.left` slots) so `omni_highlight_labels()` colored labels render **without** a per-chart `element_markdown` override.

## Verified (rendered)
- Bare `geom_col()` → chart-gray bars; axis text/titles gray.
- `omni_highlight_labels("Beta")` colors the label orange-red via the theme default, no per-chart override.
- Tricky axis labels render literally: `<18`, `65+`, `Children & Families` (the `&`), `R&D`.
- `document()` run; `omni_header` tests pass; no new test failures.

## Review notes / caveats
- **Axis-text markdown boundary:** a label containing a *matched* HTML-tag pattern (e.g. `a <b> c`) is parsed as markup (renders `a **c**`). A bare `<` / `>` (like `<18`, `>65`) renders literally — verified. This is the one behavior change worth a look; it only affects labels shaped like `<something>`, which is rare in real data.
- **Gridline color** (`steel-blue-200`) left unchanged — there's no neutral light-gray in the palette to swap to; happy to add one or hardcode a light gray if preferred.
- **`set_client_defaults()`** default `base_color` left as steel-blue — client branding is separate; can align it too on request.
- **Pre-existing test failures:** `test-design_elements.R` (3 callout-box tests) also fail on `main` locally (unrelated to this PR; they pass on CI).

## Not included (separate PR)
The default categorical palette still includes golden-yellow and is all-400-level (`omni_pal()` / `scale_*_omni_discrete()`). That's the more opinionated change (dropping golden-yellow drops the max distinct categories 6→5) and is being kept for a separate PR after a check with brand/reporting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
