### PR TITLE
Default categorical palette: 600-level, drop golden-yellow (colorblind-ordered)

### DIFF
--- a/R/colors.R
+++ b/R/colors.R
@@ -128,7 +128,9 @@ omni_colors <- function(
 #' Function to interpolate a OMNI color palette
 #'
 #' @name omni_pal
-#' @param palette Character vector of OMNI colors.
+#' @param palette Character vector of OMNI colors. The default is the 600-level
+#'   colorblind-ordered categorical palette; golden-yellow is excluded because it
+#'   fails contrast on a white background.
 #' @param reverse Boolean, should palette be reversed?
 #' @param ... Additional arguments for colorRampPalette()
 #' @return A function that generates interpolated colors.
@@ -138,12 +140,11 @@ omni_colors <- function(
 #' omni_palette(10)
 omni_pal <- function(
   palette = c(
-    "orange-red-400",
-    "golden-yellow-400",
-    "olive-green-400",
-    "teal-400",
-    "plum-400",
-    "periwinkle-400"
+    "periwinkle-600",
+    "orange-red-600",
+    "plum-600",
+    "olive-green-600",
+    "teal-600"
   ),
   reverse = FALSE,
   ...
@@ -246,7 +247,9 @@ scale_fill_omni_continuous <- function(
 #' Discrete fill scale based on OMNI colors
 #'
 #' @name scale_fill_omni_discrete
-#' @param palette Character vector of OMNI colors.
+#' @param palette Character vector of OMNI colors. The default is the 600-level
+#'   colorblind-ordered categorical palette; golden-yellow is excluded because it
+#'   fails contrast on a white background.
 #' @param reverse Boolean, should palette be reversed?
 #' @param ... Additional arguments passed to discrete_scale()
 #' @export
@@ -257,12 +260,11 @@ scale_fill_omni_continuous <- function(
 #'   scale_fill_omni_discrete()
 scale_fill_omni_discrete <- function(
   palette = c(
-    "orange-red-400",
-    "golden-yellow-400",
-    "olive-green-400",
-    "teal-400",
-    "plum-400",
-    "periwinkle-400"
+    "periwinkle-600",
+    "orange-red-600",
+    "plum-600",
+    "olive-green-600",
+    "teal-600"
   ),
   reverse = FALSE,
   ...
@@ -278,7 +280,9 @@ scale_fill_omni_discrete <- function(
 #' Discrete color scale based on OMNI colors
 #'
 #' @name scale_color_omni_discrete
-#' @param palette Character vector of OMNI colors.
+#' @param palette Character vector of OMNI colors. The default is the 600-level
+#'   colorblind-ordered categorical palette; golden-yellow is excluded because it
+#'   fails contrast on a white background.
 #' @param reverse Boolean, should palette be reversed?
 #' @param ... Additional arguments passed to discrete_scale()
 #' @export
@@ -289,12 +293,11 @@ scale_fill_omni_discrete <- function(
 #'     scale_color_omni_discrete()
 scale_color_omni_discrete <- function(
   palette = c(
-    "orange-red-400",
-    "golden-yellow-400",
-    "olive-green-400",
-    "teal-400",
-    "plum-400",
-    "periwinkle-400"
+    "periwinkle-600",
+    "orange-red-600",
+    "plum-600",
+    "olive-green-600",
+    "teal-600"
   ),
   reverse = FALSE,
   ...

--- a/man/omni_pal.Rd
+++ b/man/omni_pal.Rd
@@ -5,14 +5,16 @@
 \title{Function to interpolate a OMNI color palette}
 \usage{
 omni_pal(
-  palette = c("orange-red-400", "golden-yellow-400", "olive-green-400", "teal-400",
-    "plum-400", "periwinkle-400"),
+  palette = c("periwinkle-600", "orange-red-600", "plum-600", "olive-green-600",
+    "teal-600"),
   reverse = FALSE,
   ...
 )
 }
 \arguments{
-\item{palette}{Character vector of OMNI colors.}
+\item{palette}{Character vector of OMNI colors. The default is the 600-level
+colorblind-ordered categorical palette; golden-yellow is excluded because it
+fails contrast on a white background.}
 
 \item{reverse}{Boolean, should palette be reversed?}
 

--- a/man/scale_color_omni_discrete.Rd
+++ b/man/scale_color_omni_discrete.Rd
@@ -5,14 +5,16 @@
 \title{Discrete color scale based on OMNI colors}
 \usage{
 scale_color_omni_discrete(
-  palette = c("orange-red-400", "golden-yellow-400", "olive-green-400", "teal-400",
-    "plum-400", "periwinkle-400"),
+  palette = c("periwinkle-600", "orange-red-600", "plum-600", "olive-green-600",
+    "teal-600"),
   reverse = FALSE,
   ...
 )
 }
 \arguments{
-\item{palette}{Character vector of OMNI colors.}
+\item{palette}{Character vector of OMNI colors. The default is the 600-level
+colorblind-ordered categorical palette; golden-yellow is excluded because it
+fails contrast on a white background.}
 
 \item{reverse}{Boolean, should palette be reversed?}
 

--- a/man/scale_fill_omni_discrete.Rd
+++ b/man/scale_fill_omni_discrete.Rd
@@ -5,14 +5,16 @@
 \title{Discrete fill scale based on OMNI colors}
 \usage{
 scale_fill_omni_discrete(
-  palette = c("orange-red-400", "golden-yellow-400", "olive-green-400", "teal-400",
-    "plum-400", "periwinkle-400"),
+  palette = c("periwinkle-600", "orange-red-600", "plum-600", "olive-green-600",
+    "teal-600"),
   reverse = FALSE,
   ...
 )
 }
 \arguments{
-\item{palette}{Character vector of OMNI colors.}
+\item{palette}{Character vector of OMNI colors. The default is the 600-level
+colorblind-ordered categorical palette; golden-yellow is excluded because it
+fails contrast on a white background.}
 
 \item{reverse}{Boolean, should palette be reversed?}
 


### PR DESCRIPTION
## Summary

Bumps the **default categorical palette** to 600-level and drops golden-yellow, per Reporting BPT: golden-yellow stays a brand color for niche uses (e.g. on navy), but is excluded from viz defaults because it fails contrast on the default white background. Follow-up to the audit noted in #234.

**Change (`R/colors.R`)** — the default `palette` for `omni_pal()`, `scale_fill_omni_discrete()`, and `scale_color_omni_discrete()` goes from the 6-color **400-level** set (led by orange-red + golden-yellow) to a 5-color **600-level** set, colorblind-ordered:

```
periwinkle-600, orange-red-600, plum-600, olive-green-600, teal-600
```

- **600-level** matches the guidance ("the 600-level brand palette") and the gallery's multi-series charts — no more mixing 400/600.
- **Golden-yellow removed** from the default.
- **Order chosen by colorblind simulation** (below), not by eye.

## Colorblind validation

Each color simulated for deuteranopia / protanopia / tritanopia (`colorspace`) with CIE2000 ΔE (`farver`). Few-category charts pick the first colors, so the order maximizes worst-case distinctness of the leading colors:

| categories | min ΔE across all CB types |
|---|---|
| 2 (periwinkle, orange-red) | **44.4** — very distinct |
| 3 (+ plum) | **14.5** — clearly distinct |
| 4 (+ olive-green) | 6.8 |
| 5 (+ teal) | 6.7 |

At 4–5 categories two colors get close under deuteranopia/tritanopia (ΔE ~6.7) — inherent to a 5-hue brand palette (two greens + two blues). The order keeps the first **3** clearly distinct; for 4+ categories the guidance already recommends direct labels / small multiples over relying on color alone.

## Verified
- `document()` run (3 man pages); confirmed default = the 5-color 600 order; 5-category demo renders.
- No new test failures. (The 3 `test-design_elements.R` callout-box failures are pre-existing on `main`, unrelated to this change, and pass on CI.)

## Left intact
- `omni_colors("golden-yellow-*")` — golden-yellow remains a brand color for on-navy / menu-bar uses.
- `scale_*_omni_continuous("golden-yellow")` — explicit opt-in ramp.
- The per-family continuous ramps (200→600) — unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
