### PR TITLE
Fix: revert theme_omni axis.text to element_text (#234 regression)

### DIFF
--- a/R/theme.R
+++ b/R/theme.R
@@ -60,12 +60,7 @@ theme_omni <- function(
         size = 12,
         color = omni_colors("chart-gray")
       ),
-      # element_markdown so omni_highlight_labels() colored spans render without a
-      # per-chart override; the position-specific slots are set too because ggplot
-      # resolves those (not the parent) for the drawn tick labels
-      axis.text = ggtext::element_markdown(size = 12, color = omni_colors("chart-gray")),
-      axis.text.x.bottom = ggtext::element_markdown(size = 12, color = omni_colors("chart-gray")),
-      axis.text.y.left = ggtext::element_markdown(size = 12, color = omni_colors("chart-gray")),
+      axis.text = element_text(size = 12, color = omni_colors("chart-gray")),
       plot.title = marquee::element_marquee(
         margin = margin(0, 0, 0, 0),
         color = "#666665",


### PR DESCRIPTION
Follow-up fix to #234. The axis.text -> element_markdown default (added in #234 so `omni_highlight_labels()` would work without a per-chart override) breaks charts that blank or override axis text under ggplot2 4.0's S7 theme merging:

- **donut** (`coord_polar` + `axis.text = element_blank()`) -> error in `grid.Call.graphics()`
- **clustered bar** -> error in `merge_element()` / `plot_theme()`

The explicit position-specific slots (`axis.text.x.bottom` / `axis.text.y.left = element_markdown`) aren't cleared by a chart's `axis.text = element_blank()`, so markdown rendering leaks in.

**Fix:** revert `axis.text` to `element_text` (keeping the black -> chart-gray color fix from #234). Charts that need colored highlight labels add the per-chart `element_markdown` override, exactly as documented on `omni_highlight_labels()`. Verified both the donut and clustered charts render again.

The 3 pre-existing `test-design_elements.R` callout failures are unrelated (also fail on main locally; pass on CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)