### PR TITLE
pdf_report: fix paragraph spacing so paragraphs separate

### DIFF
--- a/inst/assets/pdf_report.css
+++ b/inst/assets/pdf_report.css
@@ -471,11 +471,15 @@ h4 {
 }
 
 /* Normal paragraph */
+/* Line spacing within a paragraph is set by line-height; the gap *between*
+   paragraphs is set by margin-bottom. These must differ or paragraphs run
+   together. Mirrors the Word brand template (Report Template.dotx): ~1.16
+   line spacing and 8pt space after each paragraph, no space before. */
 p {
   font-size: 11pt;
   font-weight: 400;
-  padding: 1pt;
-  margin: 1pt 0;
+  padding: 0;
+  margin: 0 0 8pt 0;
   line-height: 1.4;
 }
 


### PR DESCRIPTION
## Problem

In the PDF template, when a page has multiple paragraphs the space *between* paragraphs was the same as (or smaller than) the space between lines within a paragraph, so paragraphs visually ran together. Researchers were working around it by inserting manual blank lines, which over-corrects to a full line of space.

## Cause

In `inst/assets/pdf_report.css`, the body `p` rule used `line-height: 1.4` (~4.4pt leading at 11pt) but only `margin: 1pt 0` + `padding: 1pt`, so the inter-paragraph gap (~2–3pt) was smaller than the inter-line gap.

## Fix

Set the paragraph rule to `margin: 0 0 8pt 0` (and `padding: 0`), giving an 8pt gap after each paragraph — ~1.8× the inter-line leading, so paragraphs are clearly separated with no manual blank lines.

The 8pt value mirrors OMNI's Word brand template (`Report Template.dotx`), whose Normal paragraph spec is 8pt space after / 0 before and ~1.16 line spacing. `line-height` is left at the package's existing 1.4.

Scoped rules (cover page, TOC, abstract, acknowledgements) set their own margins and are unaffected. This applies to all PDF reports going forward, which is the intended brand-consistent behavior.

## Testing

CSS-only change; to verify, knit the `report-pdf` template and confirm paragraphs on a multi-paragraph page are clearly separated. Researchers can delete any manual blank lines previously added between paragraphs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)