### PR TITLE
pdf_report: fix table column widths + repeat header across page breaks

### DIFF
--- a/R/table.R
+++ b/R/table.R
@@ -1,15 +1,50 @@
-#' OMNI Table Function
+#' Create a table in OMNI's style
 #'
-#' This function creates a table in OMNI's style.
+#' Turns a data frame into a table styled with OMNI Institute's fonts,
+#' colours and row striping. The result is a \pkg{flextable} object, so it can
+#' be piped into any \pkg{flextable} function for further customisation (for
+#' example to set column widths, merge cells, or format specific rows).
 #'
-#' @param df The data frame to be put into the table
-#' @param group_by Character vector containing of grouping variables
-#' @param first_col_gray Should the first column be gray. Default to FALSE
-#' @param caption The caption of the table
-#' @param with_stripes TRUE or FALSE depending on whether a striped pattern should be used. Defaults to TRUE (which uses stripes.)
-#' @param dark_group_rows Whether or not to use a darker color (navy) for group rows when `group_by` is not NULL
+#' @param df The data frame to turn into a table.
+#' @param group_by Optional character vector of grouping variable(s). When
+#'   supplied, the data is grouped and the group-label rows are shaded.
+#'   Defaults to \code{NULL} (no grouping).
+#' @param first_col_gray Should the first column be shaded gray (with white
+#'   text)? Defaults to \code{FALSE}.
+#' @param caption The table caption. Defaults to \code{NULL} (no caption).
+#' @param with_stripes Should rows use a striped (zebra) pattern? Defaults to
+#'   \code{TRUE}.
+#' @param dark_group_rows When \code{group_by} is supplied, should the group
+#'   rows use a darker navy shade instead of steel blue? Defaults to
+#'   \code{FALSE}.
 #'
-#' @return A table themed
+#' @details
+#' By default the table uses an autofit layout and fills the width of the page
+#' or container, sizing each column to fit its content.
+#'
+#' When rendered in the OMNI PDF report, column widths are held constant where
+#' a table breaks across pages, and the header row is repeated at the top of
+#' each page the table spans. This is handled automatically and needs no extra
+#' code.
+#'
+#' To control the relative width of columns, pipe the result through
+#' \code{\link[flextable]{width}} and switch the layout to \code{"fixed"} with
+#' \code{\link[flextable]{set_table_properties}}. The widths act as
+#' proportions and are scaled to fill the available width. There must be one
+#' width per column:
+#'
+#' \preformatted{
+#' omni_table(df) |>
+#'   flextable::width(width = c(2.5, 1, 1, 1)) |>
+#'   flextable::set_table_properties(layout = "fixed", width = 1)
+#' }
+#'
+#' @return A \pkg{flextable} object (of class \code{omni_table}).
+#'
+#' @seealso \code{\link[flextable]{width}} and
+#'   \code{\link[flextable]{set_table_properties}} for adjusting column widths
+#'   and the table layout.
+#'
 #' @export
 #'
 #' @import flextable
@@ -22,32 +57,46 @@
 #' @importFrom tibble rowid_to_column
 #'
 #' @examples
+#' # Basic table
 #' palmerpenguins::penguins |>
-#'  dplyr::slice(1:3) |>
-#'    omni_table()
+#'   dplyr::slice(1:3) |>
+#'   omni_table()
 #'
-#'  palmerpenguins::penguins |>
-#'    dplyr::slice(1:3) |>
-#'    omni_table(first_col_gray = TRUE)
+#' # Shade the first column
+#' palmerpenguins::penguins |>
+#'   dplyr::slice(1:3) |>
+#'   omni_table(first_col_gray = TRUE)
 #'
-#'  palmerpenguins::penguins |>
-#'    dplyr::slice(1:3, .by = species) |>
-#'    omni_table(group_by = 'species')
+#' # Group rows by a variable
+#' palmerpenguins::penguins |>
+#'   dplyr::slice(1:3, .by = species) |>
+#'   omni_table(group_by = "species")
 #'
-#'  palmerpenguins::penguins |>
-#'    dplyr::slice(1:3) |>
-#'    omni_table(caption = 'Table 1. [Insert Table Name]')
+#' # Add a caption
+#' palmerpenguins::penguins |>
+#'   dplyr::slice(1:3) |>
+#'   omni_table(caption = "Table 1. [Insert Table Name]")
 #'
-#' # Without striped pattern
+#' # Without the striped pattern
 #' palmerpenguins::penguins |>
 #'   dplyr::slice(1:3) |>
 #'   omni_table(with_stripes = FALSE)
 #'
-#' # Overwrite number formatting by transforming to character format
+#' # Overwrite number formatting by transforming to character first
 #' palmerpenguins::penguins |>
 #'   dplyr::slice(1:3) |>
 #'   dplyr::mutate(year = as.character(year)) |>
 #'   omni_table()
+#'
+#' # Set column widths manually. Pipe through flextable::width() and switch
+#' # the layout to "fixed" so the widths are respected. The width vector needs
+#' # one entry per column (palmerpenguins::penguins has 8); here the first
+#' # column is made wider than the rest.
+#' palmerpenguins::penguins |>
+#'   dplyr::slice(1:3) |>
+#'   omni_table() |>
+#'   flextable::width(width = c(2, 1, 1, 1, 1, 1, 1, 1)) |>
+#'   flextable::set_table_properties(layout = "fixed", width = 1)
 #'
 omni_table <-
   function(

--- a/R/table.R
+++ b/R/table.R
@@ -250,6 +250,20 @@ knit_print.omni_table <- function(x, ...) {
   old_is_paged <- knitr::opts_knit$get("is.paged.js")
   on.exit(knitr::opts_knit$set("is.paged.js" = old_is_paged), add = TRUE)
 
+  # In the paged (PDF) context, give the table explicit content-proportional
+  # column widths and a fixed layout. Combined with `table-layout: fixed` in
+  # pdf_report.css this keeps columns from being recomputed (and shifting)
+  # where the table breaks across pages, while preserving the content-based
+  # proportions of the default autofit layout. Skipped when the caller has
+  # already set a fixed layout, so a manual
+  # `width() |> set_table_properties(layout = "fixed")` is left untouched.
+  if (is.null(x$properties$layout) || identical(x$properties$layout, "autofit")) {
+    col_widths <- flextable::dim_pretty(x, part = "all")$widths
+    x <- x |>
+      flextable::width(width = col_widths) |>
+      flextable::set_table_properties(layout = "fixed", width = 1)
+  }
+
   extra_class <- x$properties$opts_html$extra_class
   x$properties$opts_html$extra_class <- unique(c(extra_class, "no-shadow-dom"))
   knitr::opts_knit$set("is.paged.js" = FALSE)

--- a/inst/assets/pdf_report.css
+++ b/inst/assets/pdf_report.css
@@ -763,4 +763,10 @@ a.footnote-back {
 
 .tabwid table {
   line-height: normal !important;
+  /* Fixed layout keeps column widths identical on every page fragment.
+     With auto layout, paged.js recomputes each fragment's columns from the
+     content that lands on that page, so the same column changes width where
+     the table breaks. width:100% makes the columns fill the text area. */
+  table-layout: fixed !important;
+  width: 100% !important;
 }

--- a/inst/assets/pdf_report_js.html
+++ b/inst/assets/pdf_report_js.html
@@ -79,3 +79,82 @@
   }
   Paged.registerHandlers(endToFootNotes);
 </script>
+<script>
+  // Repeat table headers when a table breaks across pages.
+  // paged.js does not clone <thead> into the table fragments it creates on
+  // following pages, so long tables lose their header row after a page break.
+  // This handler re-inserts the header (and any <colgroup>) into each
+  // continuation fragment. Adapted from the canonical paged.js recipe:
+  // https://github.com/pagedjs/pagedjs (repeating table headers).
+  class OmniRepeatingTableHeaders extends Paged.Handler {
+    constructor(chunker, polisher, caller) {
+      super(chunker, polisher, caller);
+      this.splitTablesRefs = [];
+    }
+
+    afterPageLayout(pageElement, page, breakToken, chunker) {
+      this.chunker = chunker;
+      this.splitTablesRefs = [];
+
+      if (breakToken) {
+        const node = breakToken.node;
+        const tables = this.findAllAncestors(node, "table");
+        if (node && node.tagName === "TABLE") {
+          tables.push(node);
+        }
+        this.splitTablesRefs = tables
+          .map((t) => t.dataset.ref)
+          .filter(Boolean);
+      }
+    }
+
+    layout(rendered, layout) {
+      for (const ref of this.splitTablesRefs) {
+        const renderedTable = rendered.querySelector(`[data-ref='${ref}']`);
+        if (!renderedTable) continue;
+        if (renderedTable.getAttribute("data-repeated-headers")) continue;
+
+        const sourceTable = this.chunker.source.querySelector(
+          `[data-ref='${ref}']`
+        );
+        if (!sourceTable) continue;
+
+        this.repeatColgroup(sourceTable, renderedTable);
+        this.repeatTHead(sourceTable, renderedTable);
+        renderedTable.setAttribute("data-repeated-headers", true);
+      }
+    }
+
+    repeatColgroup(sourceTable, renderedTable) {
+      const colgroups = sourceTable.querySelectorAll("colgroup");
+      const firstChild = renderedTable.firstChild;
+      for (const cg of colgroups) {
+        renderedTable.insertBefore(cg.cloneNode(true), firstChild);
+      }
+    }
+
+    repeatTHead(sourceTable, renderedTable) {
+      const thead = sourceTable.querySelector("thead");
+      if (thead) {
+        renderedTable.insertBefore(
+          thead.cloneNode(true),
+          renderedTable.firstChild
+        );
+      }
+    }
+
+    findAllAncestors(node, selector) {
+      const ancestors = [];
+      let el = node ? node.parentNode : null;
+      while (el) {
+        if (el.matches && el.matches(selector)) {
+          ancestors.unshift(el);
+        }
+        el = el.parentNode;
+      }
+      return ancestors;
+    }
+  }
+
+  Paged.registerHandlers(OmniRepeatingTableHeaders);
+</script>

--- a/man/omni_table.Rd
+++ b/man/omni_table.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/table.R
 \name{omni_table}
 \alias{omni_table}
-\title{OMNI Table Function}
+\title{Create a table in OMNI's style}
 \usage{
 omni_table(
   df,
@@ -14,50 +14,99 @@ omni_table(
 )
 }
 \arguments{
-\item{df}{The data frame to be put into the table}
+\item{df}{The data frame to turn into a table.}
 
-\item{group_by}{Character vector containing of grouping variables}
+\item{group_by}{Optional character vector of grouping variable(s). When
+supplied, the data is grouped and the group-label rows are shaded.
+Defaults to \code{NULL} (no grouping).}
 
-\item{first_col_gray}{Should the first column be gray. Default to FALSE}
+\item{first_col_gray}{Should the first column be shaded gray (with white
+text)? Defaults to \code{FALSE}.}
 
-\item{caption}{The caption of the table}
+\item{caption}{The table caption. Defaults to \code{NULL} (no caption).}
 
-\item{with_stripes}{TRUE or FALSE depending on whether a striped pattern should be used. Defaults to TRUE (which uses stripes.)}
+\item{with_stripes}{Should rows use a striped (zebra) pattern? Defaults to
+\code{TRUE}.}
 
-\item{dark_group_rows}{Whether or not to use a darker color (navy) for group rows when `group_by` is not NULL}
+\item{dark_group_rows}{When \code{group_by} is supplied, should the group
+rows use a darker navy shade instead of steel blue? Defaults to
+\code{FALSE}.}
 }
 \value{
-A table themed
+A \pkg{flextable} object (of class \code{omni_table}).
 }
 \description{
-This function creates a table in OMNI's style.
+Turns a data frame into a table styled with OMNI Institute's fonts,
+colours and row striping. The result is a \pkg{flextable} object, so it can
+be piped into any \pkg{flextable} function for further customisation (for
+example to set column widths, merge cells, or format specific rows).
+}
+\details{
+By default the table uses an autofit layout and fills the width of the page
+or container, sizing each column to fit its content.
+
+When rendered in the OMNI PDF report, column widths are held constant where
+a table breaks across pages, and the header row is repeated at the top of
+each page the table spans. This is handled automatically and needs no extra
+code.
+
+To control the relative width of columns, pipe the result through
+\code{\link[flextable]{width}} and switch the layout to \code{"fixed"} with
+\code{\link[flextable]{set_table_properties}}. The widths act as
+proportions and are scaled to fill the available width. There must be one
+width per column:
+
+\preformatted{
+omni_table(df) |>
+  flextable::width(width = c(2.5, 1, 1, 1)) |>
+  flextable::set_table_properties(layout = "fixed", width = 1)
+}
 }
 \examples{
+# Basic table
 palmerpenguins::penguins |>
- dplyr::slice(1:3) |>
-   omni_table()
+  dplyr::slice(1:3) |>
+  omni_table()
 
- palmerpenguins::penguins |>
-   dplyr::slice(1:3) |>
-   omni_table(first_col_gray = TRUE)
+# Shade the first column
+palmerpenguins::penguins |>
+  dplyr::slice(1:3) |>
+  omni_table(first_col_gray = TRUE)
 
- palmerpenguins::penguins |>
-   dplyr::slice(1:3, .by = species) |>
-   omni_table(group_by = 'species')
+# Group rows by a variable
+palmerpenguins::penguins |>
+  dplyr::slice(1:3, .by = species) |>
+  omni_table(group_by = "species")
 
- palmerpenguins::penguins |>
-   dplyr::slice(1:3) |>
-   omni_table(caption = 'Table 1. [Insert Table Name]')
+# Add a caption
+palmerpenguins::penguins |>
+  dplyr::slice(1:3) |>
+  omni_table(caption = "Table 1. [Insert Table Name]")
 
-# Without striped pattern
+# Without the striped pattern
 palmerpenguins::penguins |>
   dplyr::slice(1:3) |>
   omni_table(with_stripes = FALSE)
 
-# Overwrite number formatting by transforming to character format
+# Overwrite number formatting by transforming to character first
 palmerpenguins::penguins |>
   dplyr::slice(1:3) |>
   dplyr::mutate(year = as.character(year)) |>
   omni_table()
 
+# Set column widths manually. Pipe through flextable::width() and switch
+# the layout to "fixed" so the widths are respected. The width vector needs
+# one entry per column (palmerpenguins::penguins has 8); here the first
+# column is made wider than the rest.
+palmerpenguins::penguins |>
+  dplyr::slice(1:3) |>
+  omni_table() |>
+  flextable::width(width = c(2, 1, 1, 1, 1, 1, 1, 1)) |>
+  flextable::set_table_properties(layout = "fixed", width = 1)
+
+}
+\seealso{
+\code{\link[flextable]{width}} and
+  \code{\link[flextable]{set_table_properties}} for adjusting column widths
+  and the table layout.
 }


### PR DESCRIPTION
## Problems

When a table breaks across pages in the PDF report:

1. **Column widths change at the break** — the same column is wider/narrower on the continuation page.
2. **The header row does not repeat** at the top of the continuation page.

## Causes

1. flextable emits `table-layout: auto`, so paged.js recomputes each fragment's columns from whatever content lands on that page.
2. Neither pagedown's bundled paged.js nor the CDN polyfill clones `<thead>` into the fragments it creates — there is no header-repeat logic.

## Fixes

1. `inst/assets/pdf_report.css` — force `table-layout: fixed; width: 100%` on `.tabwid table` so every fragment uses identical column widths.
2. `inst/assets/pdf_report_js.html` — add a paged.js handler (`OmniRepeatingTableHeaders`) that re-inserts the header (and any `<colgroup>`) into each continuation fragment.
3. `R/table.R` (`knit_print.omni_table`) — in the paged/PDF path only, compute **content-proportional** column widths with `flextable::dim_pretty()` and apply them with a fixed layout, so tables keep the content-based proportions of the old autofit layout (rather than collapsing to equal-width columns under `table-layout: fixed`). Skipped when the caller already set a fixed layout, so the manual `width() |> set_table_properties(layout = "fixed")` recipe is preserved.
4. `R/table.R` / `man/omni_table.Rd` — expanded documentation (details, examples, `@seealso`, manual column-width recipe).

## Backward compatibility (important)

- Change is **PDF-only** — gated behind the existing `is.paged.js` check, so **HTML and Word output are unaffected** and existing `omni_table()` calls need no changes.
- Existing PDF tables keep their content-based column **proportions**; the visible change is that columns no longer shift where a table breaks, and multi-page tables now repeat their header. Not pixel-identical (proportions come from `dim_pretty()` rather than the browser's auto algorithm), so teams should give tables one careful review on the next render cycle.

## Testing

Rendered multi-page tables with `omni::pdf_report()` and confirmed page-by-page: column widths are identical across the break, proportions match the original content-based layout, and the header repeats at the top of each page with no duplicate header/caption on the first fragment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)