### PR TITLE
Bump version to 1.1.0 and add NEWS.md

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Type: Package
 Package: omni
 Title: RMarkdown template, ggplot2 theme, and table function for OMNI
     Institute
-Version: 1.0.2023
+Version: 1.1.0
 Description: RMarkdown template, ggplot2 theme, and table function for
     OMNI Institute.
 License: file LICENSE

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,18 @@
+# omni 1.1.0
+
+## PDF report tables
+
+* Table columns no longer change width where a table breaks across pages.
+  Tables now keep consistent, content-proportional column widths on every
+  page (#238).
+* Table header rows now repeat at the top of each page a table spans (#238).
+* `omni_table()` gained a fuller help page, including how to set column
+  widths manually with `flextable::width()` and
+  `flextable::set_table_properties(layout = "fixed")` (#238).
+
+## PDF report layout
+
+* Fixed the spacing between paragraphs so paragraphs are clearly separated.
+  Previously the gap between paragraphs matched the line spacing within a
+  paragraph, so paragraphs ran together; manual blank lines are no longer
+  needed to separate them (#237).


### PR DESCRIPTION
Records the PDF report fixes merged this cycle and starts a changelog.

## Changes
- **Version:** `1.0.2023` → `1.1.0`. Conventional minor bump for this batch of user-facing fixes + the new repeating-header behavior, and unambiguously newer than the previous version. (The old `1.0.2023` didn't follow a clear scheme — happy to use a different number if your team prefers one; just edit before merging.)
- **`NEWS.md`:** new changelog covering #237 (paragraph spacing) and #238 (table column-width stability across page breaks, repeating table headers, expanded `omni_table()` docs).

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)