### PR TITLE
omni_table: drop white horizontal row separators

### DIFF
--- a/R/table.R
+++ b/R/table.R
@@ -134,7 +134,12 @@ omni_table <-
       color(part = "header", color = "white") |>
       color(part = "body", color = "#333333") |>
       height_all(height = 0.4) |>
-      border_inner(part = "all", border = fp_border(color = "white"))
+      # Vertical (column) separators only. Horizontal white row separators are
+      # omitted: on striped tables the zebra shading already separates rows, and
+      # on unstriped (all-white) tables white lines are invisible anyway. Thin
+      # white horizontal lines over the grey fill could also render as a faint
+      # double line / shading spillover in some PDF viewers.
+      border_inner_v(part = "all", border = fp_border(color = "white"))
 
     # highlight grouped row
     if (!is.null(group_by)) {


### PR DESCRIPTION
Client-driven refinement: remove the thin white horizontal lines between table rows, keeping the vertical column dividers. Switches `border_inner()` to `border_inner_v()` in `omni_table()`.

## Why

A client flagged a faint "double line / shading spillover" near the bottom of grey cells in a PDF. It's a viewer-side sub-pixel rendering artifact from the 1pt white horizontal lines drawn over the grey zebra fill. Beyond the artifact, those lines aren't doing useful work:

- **Striped tables:** the zebra shading already separates rows — the white lines are decorative.
- **Unstriped (all-white) tables:** the white lines are invisible on white, so rows already had no visible separator. This change is a no-op there.

Verified with mockups (striped and unstriped) and a multi-page render: the table looks essentially the same, the artifact's cause is gone, and it still works with the page-break column-stability and repeating-header fixes.

## Scope / impact

- Applies to **all outputs** (HTML, Word, PDF) so the table style stays consistent across formats.
- Brand-style change to the default `omni_table()` look — intended for review by the reporting best-practices team before merge.
- No API change; existing calls are unaffected.

## Note

Should ship in the 1.1.0 release alongside #239 (version bump + NEWS). I can add a NEWS bullet once #239 lands, or fold it in — say the word.

🤖 Generated with [Claude Code](https://claude.com/claude-code)