### PR TITLE
Discrete color scales: take the first k brand colors, not an interpolated ramp

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,14 @@
 # omni 1.1.0
 
+## ggplot color scales
+
+* `scale_fill_omni_discrete()` and `scale_color_omni_discrete()` now use the
+  first *k* palette colors for *k* categories instead of interpolating *k*
+  colors across the five-color ramp. Categorical charts get the exact brand
+  colors at every count (three categories are periwinkle, orange-red and plum;
+  four add olive-green), and the scale errors clearly when more categories than
+  palette colors are requested (#242).
+
 ## PDF report tables
 
 * Table columns no longer change width where a table breaks across pages.

--- a/R/colors.R
+++ b/R/colors.R
@@ -158,6 +158,55 @@ omni_pal <- function(
   grDevices::colorRampPalette(pal, ...)
 }
 
+#' First-k discrete OMNI palette
+#'
+#' Returns a palette function for [ggplot2::discrete_scale()] that hands back the
+#' first `n` colors of `palette`, in order, rather than interpolating `n` colors
+#' across them (which is what [omni_pal()] does for the continuous scales).
+#' Categorical data should get the exact brand colors, so a three-category chart
+#' uses the first three palette colors and a five-category chart uses all five.
+#'
+#' @param palette Character vector of OMNI colors.
+#' @param reverse Boolean, should the palette be reversed?
+#' @return A function of `n` returning the first `n` palette colors.
+#' @noRd
+omni_pal_discrete <- function(
+  palette = c(
+    "periwinkle-600",
+    "orange-red-600",
+    "plum-600",
+    "olive-green-600",
+    "teal-600"
+  ),
+  reverse = FALSE
+) {
+  pal <- unname(omni_colors(palette))
+
+  if (reverse) {
+    pal <- rev(pal)
+  }
+
+  function(n) {
+    if (n > length(pal)) {
+      stop(
+        sprintf(
+          paste0(
+            "The OMNI categorical palette has %d colors but %d categories were ",
+            "requested. Reduce the number of categories (facet into small ",
+            "multiples, group the smaller categories, or highlight one), or pass ",
+            "a longer `palette`."
+          ),
+          length(pal),
+          n
+        ),
+        call. = FALSE
+      )
+    }
+
+    pal[seq_len(n)]
+  }
+}
+
 
 #' Continuous color scale based on OMNI colors
 #'
@@ -272,7 +321,7 @@ scale_fill_omni_discrete <- function(
   ggplot2::discrete_scale(
     aesthetics = "fill",
     scale_name = "omni",
-    palette = omni_pal(palette, reverse),
+    palette = omni_pal_discrete(palette, reverse),
     ...
   )
 }
@@ -305,7 +354,7 @@ scale_color_omni_discrete <- function(
   ggplot2::discrete_scale(
     aesthetics = "color",
     scale_name = "omni",
-    palette = omni_pal(palette, reverse),
+    palette = omni_pal_discrete(palette, reverse),
     ...
   )
 }

--- a/R/colors.R
+++ b/R/colors.R
@@ -304,7 +304,7 @@ scale_fill_omni_continuous <- function(
 #' @export
 #' @examples
 #' library(ggplot2)
-#' ggplot(mpg, aes(x = class, fill = class)) +
+#' ggplot(mpg, aes(x = drv, fill = drv)) +
 #'   geom_bar() +
 #'   scale_fill_omni_discrete()
 scale_fill_omni_discrete <- function(
@@ -337,7 +337,7 @@ scale_fill_omni_discrete <- function(
 #' @export
 #' @examples
 #' library(ggplot2)
-#' ggplot(mpg, aes(x = displ, y = hwy, color = class)) +
+#' ggplot(mpg, aes(x = displ, y = hwy, color = drv)) +
 #'     geom_point(size = 2.5) +
 #'     scale_color_omni_discrete()
 scale_color_omni_discrete <- function(

--- a/man/scale_color_omni_discrete.Rd
+++ b/man/scale_color_omni_discrete.Rd
@@ -25,7 +25,7 @@ Discrete color scale based on OMNI colors
 }
 \examples{
 library(ggplot2)
-ggplot(mpg, aes(x = displ, y = hwy, color = class)) +
+ggplot(mpg, aes(x = displ, y = hwy, color = drv)) +
     geom_point(size = 2.5) +
     scale_color_omni_discrete()
 }

--- a/man/scale_fill_omni_discrete.Rd
+++ b/man/scale_fill_omni_discrete.Rd
@@ -25,7 +25,7 @@ Discrete fill scale based on OMNI colors
 }
 \examples{
 library(ggplot2)
-ggplot(mpg, aes(x = class, fill = class)) +
+ggplot(mpg, aes(x = drv, fill = drv)) +
   geom_bar() +
   scale_fill_omni_discrete()
 }

--- a/tests/testthat/test-colors.R
+++ b/tests/testthat/test-colors.R
@@ -1,0 +1,46 @@
+test_that("omni_pal_discrete returns the first k brand colors, in order", {
+  expect_equal(
+    omni_pal_discrete()(3),
+    unname(omni_colors(c("periwinkle-600", "orange-red-600", "plum-600")))
+  )
+
+  expect_equal(
+    omni_pal_discrete()(5),
+    unname(omni_colors(c(
+      "periwinkle-600",
+      "orange-red-600",
+      "plum-600",
+      "olive-green-600",
+      "teal-600"
+    )))
+  )
+})
+
+test_that("omni_pal_discrete reverses the palette when asked", {
+  # reversing the full five then taking the first two yields teal, olive-green
+  expect_equal(
+    omni_pal_discrete(reverse = TRUE)(2),
+    unname(omni_colors(c("teal-600", "olive-green-600")))
+  )
+})
+
+test_that("the discrete scales use first-k selection, not interpolation", {
+  # 4 categories must be exact brand colors, not interpolated midtones
+  expect_equal(
+    scale_fill_omni_discrete()$palette(4),
+    unname(omni_colors(c(
+      "periwinkle-600",
+      "orange-red-600",
+      "plum-600",
+      "olive-green-600"
+    )))
+  )
+  expect_equal(
+    scale_color_omni_discrete()$palette(3),
+    unname(omni_colors(c("periwinkle-600", "orange-red-600", "plum-600")))
+  )
+})
+
+test_that("requesting more categories than the palette has errors clearly", {
+  expect_error(omni_pal_discrete()(6), "categories")
+})

--- a/tests/testthat/test-colors.R
+++ b/tests/testthat/test-colors.R
@@ -25,9 +25,14 @@ test_that("omni_pal_discrete reverses the palette when asked", {
 })
 
 test_that("the discrete scales use first-k selection, not interpolation", {
+  # suppressWarnings: building the scale trips ggplot2's unrelated, pre-existing
+  # discrete_scale(scale_name=) deprecation; we only care about the palette here.
+  fill_scale <- suppressWarnings(scale_fill_omni_discrete())
+  color_scale <- suppressWarnings(scale_color_omni_discrete())
+
   # 4 categories must be exact brand colors, not interpolated midtones
   expect_equal(
-    scale_fill_omni_discrete()$palette(4),
+    fill_scale$palette(4),
     unname(omni_colors(c(
       "periwinkle-600",
       "orange-red-600",
@@ -36,7 +41,7 @@ test_that("the discrete scales use first-k selection, not interpolation", {
     )))
   )
   expect_equal(
-    scale_color_omni_discrete()$palette(3),
+    color_scale$palette(3),
     unname(omni_colors(c("periwinkle-600", "orange-red-600", "plum-600")))
   )
 })


### PR DESCRIPTION
## The problem

`scale_fill_omni_discrete()` / `scale_color_omni_discrete()` passed `omni_pal()` — a
`colorRampPalette()` closure — straight to `discrete_scale()`. ggplot then calls that closure with
`n` (the number of categories), so it **interpolates** `n` colors across the five-color ramp rather
than handing back the categorical brand colors:

| categories | colors returned | |
|---|---|---|
| 2 | `#5776B2 #41816F` | periwinkle, teal (endpoints) |
| 3 | `#5776B2 #921C4C #41816F` | periwinkle, plum, teal |
| 4 | `#5776B2` **`#B83419 #584139`** `#41816F` | two **off-brand** interpolated midtones |
| 5 | `#5776B2 #CC4100 #921C4C #3B5530 #41816F` | the five brand colors |

So four-category charts get muddy non-brand colors, and the "colorblind-ordered, greens-last"
ordering of the default palette (from #235) isn't actually used — that ordering is designed for
*take-first-k* selection.

## The fix

Add an internal `omni_pal_discrete()` that returns the **first `k` colors of the palette, in
order** (3 → periwinkle, orange-red, plum; 4 adds olive-green; 5 is all five), and point both
discrete scales at it. It errors clearly when more categories than colors are requested. `omni_pal()`
(the ramp) is unchanged and still backs the continuous scales.

Adds `tests/testthat/test-colors.R` covering first-k selection, `reverse`, the discrete scales'
`$palette()`, and the too-many-categories error. All green locally.