### PR TITLE
html_report: match heading spacing to the Word brand template

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -33,3 +33,7 @@
 
 * The report footer now shows the year the report is knitted rather than a
   hard-coded year, so it no longer needs a manual update each January (#243).
+* Fixed spacing above and below section headings (h1-h4) so it matches the
+  Word brand template (Report Template.dotx). Previously every heading level
+  used the same spacing, which didn't match Word's per-level spacing and, for
+  h1, was visibly tighter than the gap under a top-level heading in Word.

--- a/inst/assets/html_report.css
+++ b/inst/assets/html_report.css
@@ -108,7 +108,31 @@ h2:not(#header h2),
 h3:not(#header h3),
 h4:not(#header h4) {
   font-family: var(--header-font);
-  margin-top: 50px;
+}
+
+/* Space above/below each heading level, matched to the rendered gaps in
+   the Word brand template (Report Template.dotx). Word's own "space
+   before/after" paragraph attributes don't map 1:1 to the visual gap
+   because of line-height/leading, so these are measured pixel gaps from
+   an actual Word-rendered PDF, not the raw docx spacing values. */
+h1:not(#header h1) {
+  margin-top: 20pt;
+  margin-bottom: 9pt;
+}
+
+h2:not(#header h2) {
+  margin-top: 11pt;
+  margin-bottom: 8pt;
+}
+
+h3:not(#header h3) {
+  margin-top: 15pt;
+  margin-bottom: 0pt;
+}
+
+h4:not(#header h4) {
+  margin-top: 11pt;
+  margin-bottom: 5pt;
 }
 
 h2 {


### PR DESCRIPTION
Replace the single margin-top:50px rule shared by h1-h4 with per-level margin-top/margin-bottom, derived by rendering the actual Word template (Report Template.dotx) to PDF and measuring the real visual gaps rather than the raw docx spacing attributes (which don't account for line-height/leading and understate the true gap).