### PR TITLE
pdf_report: match heading spacing to the Word brand template

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -28,6 +28,10 @@
   Previously the gap between paragraphs matched the line spacing within a
   paragraph, so paragraphs ran together; manual blank lines are no longer
   needed to separate them (#237).
+* Fixed spacing above and below section headings (`##`/`###`/`####`) so it
+  matches the Word brand template (Report Template.dotx). The primary
+  heading level (`##`) previously had almost no space below it before body
+  text, and the two lower levels had spacing that didn't match Word either.
 
 ## HTML report
 

--- a/inst/assets/pdf_report.css
+++ b/inst/assets/pdf_report.css
@@ -446,16 +446,17 @@ h1 {
 }
 
 h2 {
-  margin-block-end: 0 !important;
+  margin-block-end: 8pt !important;
   font-size: 30pt;
   font-weight: 400;
   letter-spacing: 0.03em;
   color: var(--primary-color);
-  margin-top: 0 !important;
+  margin-top: 18pt !important;
 }
 
 h3 {
   margin-block-end: 8pt !important;
+  margin-top: 9pt !important;
   font-size: 16pt;
   font-weight: 400;
   letter-spacing: 0.03em;
@@ -463,7 +464,8 @@ h3 {
 }
 
 h4 {
-  margin-block-end: 5.5pt !important;
+  margin-block-end: 0pt !important;
+  margin-top: 13pt !important;
   font-size: 13pt;
   font-weight: 400;
   letter-spacing: 0.03em;


### PR DESCRIPTION
h2 (primary heading, e.g. "Conclusion") had margin-top/margin-block-end both forced to 0, leaving almost no visual gap before body text - h3 and h4 had some spacing but not matched to Word either.

Measured the real gaps in a Word-rendered PDF of Report Template.dotx (same method used for the html_report fix in #257) and solved for the margin values needed in this rendering pipeline, where the visible gap is max(previous element's margin-bottom, heading's margin-top) plus a small consistent rendering offset - not a simple sum. Verified by rendering omni::pdf_report() and measuring the actual output with pdftools::pdf_data().