### PR TITLE
html_report: fix heading-level mapping in the spacing fix from #257

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -38,3 +38,8 @@
   used the same spacing, which didn't match Word's per-level spacing and, for
   h1, was visibly tighter than the gap under a top-level heading in Word
   (#257).
+* Corrected which heading level receives which spacing from the fix above.
+  The report-html skeleton starts sections at `##`, not `#`, so h2/h3/h4 are
+  the levels actually used for primary/subtopic/sub-subtopic headings in
+  practice; the previous fix had applied each level's spacing one tag too
+  high.

--- a/inst/assets/html_report.css
+++ b/inst/assets/html_report.css
@@ -114,25 +114,29 @@ h4:not(#header h4) {
    the Word brand template (Report Template.dotx). Word's own "space
    before/after" paragraph attributes don't map 1:1 to the visual gap
    because of line-height/leading, so these are measured pixel gaps from
-   an actual Word-rendered PDF, not the raw docx spacing values. */
-h1:not(#header h1) {
+   an actual Word-rendered PDF, not the raw docx spacing values.
+
+   The report-html skeleton starts sections at "##", not "#" - the
+   document title comes from YAML front matter, so h1 is never a real
+   section heading in practice. h2 is the primary section heading, h3 is
+   the subtopic, h4 the sub-subtopic - one level down from what the tag
+   name suggests - so these rules target Word's heading levels shifted
+   accordingly (h1 keeps the top-level values in case anyone still uses
+   a bare "#"). */
+h1:not(#header h1),
+h2:not(#header h2) {
   margin-top: 20pt;
   margin-bottom: 9pt;
 }
 
-h2:not(#header h2) {
+h3:not(#header h3) {
   margin-top: 11pt;
   margin-bottom: 8pt;
 }
 
-h3:not(#header h3) {
+h4:not(#header h4) {
   margin-top: 15pt;
   margin-bottom: 0pt;
-}
-
-h4:not(#header h4) {
-  margin-top: 11pt;
-  margin-bottom: 5pt;
 }
 
 h2 {


### PR DESCRIPTION
The report-html skeleton starts sections at "##" (h2), not "#" (h1) - the document title comes from YAML front matter, so h1 is never a real section heading in practice. The #257 fix set each level's Word-matched spacing on the wrong tag as a result: h2 (the real primary heading) got the subtopic spacing, h3 got the sub-subtopic spacing, and so on. Shifts the values down one level so h2/h3/h4 (primary/subtopic/sub-subtopic in practice) get the correct Word-matched spacing.