### PR TITLE
html_report: match paragraph and list spacing to the Word brand template

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -38,3 +38,6 @@
   used the same spacing, which didn't match Word's per-level spacing and, for
   h1, was visibly tighter than the gap under a top-level heading in Word
   (#257).
+* Fixed spacing between paragraphs and around bulleted/numbered lists, which
+  was noticeably tighter than the Word brand template. Paragraph-to-paragraph
+  and list spacing now match the gaps in Word.

--- a/inst/assets/html_report.css
+++ b/inst/assets/html_report.css
@@ -150,9 +150,23 @@ h3 {
 }
 
 /* Normal paragraph */
+/* margin-bottom matches the measured paragraph-to-paragraph gap in the
+   Word brand template (Report Template.dotx) — see the heading rules
+   above for how this was measured (rendered output, not the raw docx
+   spacing attributes). */
 p {
   font-size: 14pt;
   font-weight: 400;
+  margin: 0 0 10pt 0;
+}
+
+/* Space around bulleted/numbered lists, matched to the Word template the
+   same way as the paragraph and heading spacing above. Excludes the
+   sidebar TOC, which has its own spacing. */
+ul:not(#TOC ul),
+ol:not(#TOC ol) {
+  margin-top: 12pt;
+  margin-bottom: 9pt;
 }
 
 #TOC {


### PR DESCRIPTION
Paragraph-to-paragraph and list spacing relied entirely on Bootstrap's default margins, which were consistently tighter than the Word template. Measured the real gaps in a rendered PDF of Report Template.dotx (same method as the heading-spacing fix) and set explicit margins to match: paragraph-to-paragraph 10pt, paragraph-to-list 12pt, list-to-paragraph 9pt.