### PR TITLE
pdf_report: document known limitation with heading spacing at page top

### DIFF
--- a/inst/assets/pdf_report.css
+++ b/inst/assets/pdf_report.css
@@ -438,6 +438,26 @@ h1.subtitle:nth-child(2):not(.abstract h1)::before {
 }
 
 /* Levels of title */
+/* Known limitation: margin-top on h2/h3/h4 below is not trimmed when a
+   heading happens to land at the top of a printed page - paged.js (the
+   pagination engine behind this PDF output) doesn't implement the part of
+   the CSS Fragmentation spec that discards a box's margin at a page-break
+   boundary. Confirmed by rendering test docs and forcing headings to the
+   top of a page: the heading's own margin-top survives the break in full,
+   while a trailing margin-bottom on the element before it is correctly
+   discarded. That second fact means the fix - moving this spacing onto
+   the *previous* element's margin-bottom instead of the heading's
+   margin-top - is possible in principle, but pandoc wraps every section in
+   its own nested <div>, so "the previous element" is the wrapping div of
+   the prior section, not a direct sibling of the heading. Selecting it
+   correctly needs to special-case every block type a section can end
+   with (paragraph, list, table, image, quote_box()/callout_box()), and
+   silently loses the spacing for any type not covered. Given that, this
+   was left as an accepted, purely cosmetic limitation rather than fixed:
+   the extra space above a heading at the top of a page is the same
+   spacing that correctly separates it from body text everywhere else, it
+   just has nothing to visually separate from when there's no preceding
+   line on that page. */
 h1 {
   font-size: 24pt;
   font-weight: 700;


### PR DESCRIPTION
Documents (no behavior change) why headings sometimes have visibly more space above them when they land at the top of a printed page - not a bug, a limitation of paged.js not trimming margins at page-break boundaries.

Confirmed by forcing headings to the top of a page in test renders and measuring: the heading's `margin-top` survives a page break in full; a trailing `margin-bottom` on the element before it is correctly discarded. Investigated the natural fix (move spacing to the previous element's margin-bottom) but it doesn't generalize past sections ending in a plain paragraph - pandoc's per-section div nesting means the real "previous element" is a wrapper div, and a working selector would need to special-case every block type a section can end with (list, table, image, `quote_box()`/`callout_box()`).

Left as an accepted, documented limitation - not a bug to "quickly fix" if it comes up again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)