### PR TITLE
omni_header: fix finding_keyword rendering gray instead of color

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,19 @@
   four add olive-green), and the scale errors clearly when more categories than
   palette colors are requested (#242).
 
+## omni_header()
+
+* Fixed `finding_keyword` (the secondary-finding stripe/text in the caption)
+  silently rendering gray instead of `color`. It colors via marquee markdown
+  (`{.color ...}`), which only resolves if `plot.caption`'s style has that
+  color registered as a tag - `omni_header()` was never supplying that style
+  itself, so it only worked by accident, when `theme_omni()`'s own
+  `plot.caption` element (which does carry the right style) was still in
+  place immediately beforehand for ggplot2's theme-merge to inherit it from.
+  Any code resetting `plot.caption` first - including a fix for an unrelated
+  title/subtitle theme-merge issue - broke it. `omni_header()` now supplies
+  its own style unconditionally, independent of theme order.
+
 ## PDF report tables
 
 * Table columns no longer change width where a table breaks across pages.

--- a/R/omni_header.R
+++ b/R/omni_header.R
@@ -146,7 +146,14 @@ omni_header <- function(
         padding = ggplot2::margin(0, 0, 0, 0)
       ),
       plot.subtitle = ggplot2::element_text(colour = hex_gray),
-      plot.caption = marquee::element_marquee(hjust = 0, colour = hex_gray)
+      # style is passed explicitly (not inherited from whatever plot.caption
+      # element theme_omni() or the caller left behind) so the {.color ...}
+      # class markdown built above always resolves, regardless of theme order
+      plot.caption = marquee::element_marquee(
+        hjust = 0,
+        colour = hex_gray,
+        style = .omni_marquee_style()
+      )
     )
   )
 }

--- a/R/theme.R
+++ b/R/theme.R
@@ -1,3 +1,41 @@
+#' Build the marquee style shared by Omni's title/subtitle/caption text
+#'
+#' Registers each brand color name (e.g. `"plum-600"`) as a marquee tag, so
+#' `{.plum-600 text}` markdown resolves to that color. Used by [theme_omni()]
+#' (which layers per-slot overrides, e.g. size/weight, on top of this) and by
+#' [omni_header()]'s `plot.caption`, which needs the same color tags
+#' available for `finding_keyword` but builds its own `element_marquee()`
+#' independently of whatever theme is already applied - it must not rely on
+#' inheriting a style from a prior `plot.caption` element via ggplot2's
+#' theme-merge behavior, which only backfills unset fields when one exists
+#' to backfill from.
+#'
+#' @noRd
+.omni_marquee_style <- function() {
+  style_wo_colors <- marquee::style_set(
+    base = marquee::base_style(weight = "bold", size = 13),
+    str = marquee::style(weight = "bold"),
+    em = marquee::style(italic = TRUE),
+    u = marquee::style(underline = TRUE)
+  )
+
+  colors_named <- omni_colors(named = TRUE)
+  purrr::reduce2(
+    .x = names(colors_named),
+    # color names
+    .y = unname(colors_named),
+    # color hex codes
+    .f = \(style, color_name, color_hex) {
+      style |>
+        marquee::modify_style(
+          tag = color_name,
+          color = color_hex
+        )
+    },
+    .init = style_wo_colors
+  )
+}
+
 #' OMNI Institute ggplot2 theme
 #'
 #' @description Applies the OMNI Institute theme to the plot.
@@ -18,29 +56,7 @@ theme_omni <- function(
   base_family = "Inter Tight",
   plot_background_color = "White"
 ) {
-  style_wo_colors <- marquee::style_set(
-    base = marquee::base_style(weight = "bold", size = 13),
-    str = marquee::style(weight = "bold"),
-    em = marquee::style(italic = TRUE),
-    u = marquee::style(underline = TRUE)
-  )
-
-  # Iteratively add the color tag styles
-  omni_colors <- omni_colors(named = TRUE)
-  omni_style <- purrr::reduce2(
-    .x = names(omni_colors),
-    # color names
-    .y = unname(omni_colors),
-    # color hex codes
-    .f = \(style, color_name, color_hex) {
-      style |>
-        marquee::modify_style(
-          tag = color_name,
-          color = color_hex
-        )
-    },
-    .init = style_wo_colors
-  )
+  omni_style <- .omni_marquee_style()
   # general theme based on theme_minimal
   omni_theme <- theme_minimal(base_family = base_family) +
     theme(

--- a/tests/testthat/test-omni_header.R
+++ b/tests/testthat/test-omni_header.R
@@ -34,6 +34,26 @@ test_that("omni_header colors the keyword and warns on a missing one", {
   expect_warning(omni_header(primary = "Housing led", keyword = "Nope"))
 })
 
+test_that("omni_header's caption carries its own marquee style (regression: finding_keyword gray fallback)", {
+  # omni_header()'s finding_keyword coloring works by wrapping it in marquee
+  # class markdown (e.g. "{.plum-600 ...}"), which only resolves to a color
+  # if plot.caption's element_marquee() has a style with that class
+  # registered. It must supply that style itself rather than relying on
+  # ggplot2's theme-merge to backfill it from a pre-existing plot.caption
+  # element (e.g. theme_omni()'s) - that only works by accident, and breaks
+  # the moment anything resets plot.caption first (as a fix for the
+  # title/subtitle theme-merge issue does).
+  h <- omni_header(
+    primary = "Test finding",
+    finding = "A second point",
+    finding_keyword = "second",
+    color = "plum-600"
+  )
+  caption_style <- h[[2]]$plot.caption$style
+  expect_false(is.null(caption_style))
+  expect_identical(caption_style, .omni_marquee_style())
+})
+
 test_that("omni_highlight_labels colors only matched labels", {
   labeller <- omni_highlight_labels("North", color = "teal-600")
   out <- labeller(c("North", "South"))


### PR DESCRIPTION
## Bug

`omni_header()`'s documented contract says `color =` colors both the title keyword and the secondary-finding (`finding_keyword`) stripe/text. That's only reliably true for the title.

`finding_keyword` colors via marquee class markdown (`{.color ...}`), which only resolves to an actual color if `plot.caption`'s `element_marquee()` has a style with that color name registered as a tag. `omni_header()` built that element without ever setting `style`:

```r
plot.caption = marquee::element_marquee(hjust = 0, colour = hex_gray)
```

This worked, but only by accident: `theme_omni()` builds its own style with all five brand colors registered as marquee tags (`omni_style`) and installs it on its own `plot.caption`. ggplot2's theme-merge backfills unset fields on a new element from the old one it's replacing - so as long as `theme_omni()`'s `plot.caption` was still installed immediately before `omni_header()` ran, `style` got silently inherited and everything worked. The moment anything resets `plot.caption` first - including a fix for a separate, unrelated title/subtitle theme-merge conflict - there's nothing left with a `style` field to inherit from, so `style` stays `NULL`, marquee falls back to its own default (unregistered) style, and the class reference resolves to nothing - rendering gray.

## Fix

Extracted the color-registering style construction already used by `theme_omni()` into a shared internal helper, `.omni_marquee_style()`, and had `omni_header()` pass it explicitly to its `plot.caption`. Caption coloring no longer depends on theme-merge order, or on `theme_omni()` having been applied at all.

## Verification

Rendered the same plot two ways, changing only whether `plot.caption` is reset before `omni_header()` runs:
- No reset: caption colored correctly both before and after this fix (no regression).
- With reset (the scenario that reproduces the bug): gray before this fix, correctly colored after.

Also ran `theme_omni()` alone (no `omni_header()`) with marquee color-class markdown in title/caption directly - unaffected by moving the style construction into a shared helper.

Added a regression test asserting `omni_header()`'s `plot.caption$style` is non-null and identical to the shared helper's output, so this can't silently regress again. Full test suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)