### PR TITLE
pdf_report: add manual escape hatch for a heading at the top of a page

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -45,6 +45,14 @@
   matches the Word brand template (Report Template.dotx). The primary
   heading level (`##`) previously had almost no space below it before body
   text, and the two lower levels had spacing that didn't match Word either.
+* Added a manual fix for a heading that lands at the top of a printed page:
+  the normal spacing above a heading looks like too much space there since
+  there's nothing above it on that page to separate from, and the renderer
+  has no way to detect that position automatically at CSS-authoring time.
+  After knitting, wrap a heading that visibly lands at the top of a page in
+  a fenced div with the new `remove-header-space` class and re-knit:
+  `::: {.remove-header-space}` / `## My Heading` / `:::`. Only that
+  heading's top spacing is removed; every other heading is unaffected.
 
 ## HTML report
 

--- a/R/formats.R
+++ b/R/formats.R
@@ -16,6 +16,18 @@ word_report <- function(...) {
 
 #' Omni Paged PDF Report
 #'
+#' @details
+#' Because page breaks depend on where content happens to fall, some layout
+#' issues only show up after knitting and are best fixed by hand, iteratively,
+#' rather than automatically. Force a page break with a `\\newpage` on its own
+#' line. If a `##`/`###`/`####` heading lands at the top of a page (so its
+#' normal spacing above it looks like too much, with nothing above it on
+#' that page to visually separate from), wrap just that heading in a fenced
+#' div with the `remove-header-space` class and re-knit, e.g.
+#' `::: \{.remove-header-space\}` then `## My Heading` then `:::` on their own
+#' lines. Only that heading is affected; every other heading keeps its
+#' normal spacing.
+#'
 #' @param main_font Main font
 #' @param secondary_font Secondary font
 #' @param background_cover_image Image to use for the background in the cover page. It must be one of (case insensitive): `c("01-yellow", "02-teal", "03-orangered", "06-teal", "07-periwinkle", "07-olive", "08-plum")`.

--- a/R/formats.R
+++ b/R/formats.R
@@ -17,16 +17,15 @@ word_report <- function(...) {
 #' Omni Paged PDF Report
 #'
 #' @details
-#' Because page breaks depend on where content happens to fall, some layout
-#' issues only show up after knitting and are best fixed by hand, iteratively,
-#' rather than automatically. Force a page break with a `\\newpage` on its own
-#' line. If a `##`/`###`/`####` heading lands at the top of a page (so its
-#' normal spacing above it looks like too much, with nothing above it on
-#' that page to visually separate from), wrap just that heading in a fenced
-#' div with the `remove-header-space` class and re-knit, e.g.
-#' `::: \{.remove-header-space\}` then `## My Heading` then `:::` on their own
-#' lines. Only that heading is affected; every other heading keeps its
-#' normal spacing.
+#' If a `##`/`###`/`####` heading lands at the top of a page (so its normal
+#' spacing above it looks like too much, with nothing above it on that page
+#' to visually separate from), that position depends on where content
+#' happens to break across pages and can't be detected automatically at
+#' CSS-authoring time. Fix it by hand instead, after knitting: wrap the
+#' heading in a fenced div with the `remove-header-space` class and re-knit,
+#' e.g. `::: \{.remove-header-space\}` then `## My Heading` then `:::` on
+#' their own lines. Only that heading is affected; every other heading
+#' keeps its normal spacing.
 #'
 #' @param main_font Main font
 #' @param secondary_font Secondary font

--- a/inst/assets/pdf_report.css
+++ b/inst/assets/pdf_report.css
@@ -472,6 +472,28 @@ h4 {
   color: var(--primary-color);
 }
 
+/* Manual fix for a heading that lands at the top of a printed page: the
+   margin-top values above give correct, deliberate spacing when a heading
+   follows body text on the same page, but that same margin isn't trimmed
+   when the heading happens to start a new page instead - there's nothing
+   above it there to visually separate from, so it looks like too much
+   space. There's no way to detect that position automatically at CSS-authoring
+   time (it depends on where content happens to break across pages, which
+   shifts as content changes), so this is an opt-in, per-heading override:
+   after knitting, if a heading visibly lands at the top of a page, wrap
+   just that heading in a fenced div with this class and re-knit -
+     ::: {.remove-header-space}
+     ## My Heading
+     :::
+   Only that heading's top margin is removed; every other heading's normal
+   spacing is unaffected. */
+.remove-header-space h1,
+.remove-header-space h2,
+.remove-header-space h3,
+.remove-header-space h4 {
+  margin-top: 0pt !important;
+}
+
 /* Normal paragraph */
 /* Line spacing within a paragraph is set by line-height; the gap *between*
    paragraphs is set by margin-bottom. These must differ or paragraphs run

--- a/man/pdf_report.Rd
+++ b/man/pdf_report.Rd
@@ -54,14 +54,13 @@ An rmd format
 Omni Paged PDF Report
 }
 \details{
-Because page breaks depend on where content happens to fall, some layout
-issues only show up after knitting and are best fixed by hand, iteratively,
-rather than automatically. Force a page break with a `\\newpage` on its own
-line. If a `##`/`###`/`####` heading lands at the top of a page (so its
-normal spacing above it looks like too much, with nothing above it on
-that page to visually separate from), wrap just that heading in a fenced
-div with the `remove-header-space` class and re-knit, e.g.
-`::: \{.remove-header-space\}` then `## My Heading` then `:::` on their own
-lines. Only that heading is affected; every other heading keeps its
-normal spacing.
+If a `##`/`###`/`####` heading lands at the top of a page (so its normal
+spacing above it looks like too much, with nothing above it on that page
+to visually separate from), that position depends on where content
+happens to break across pages and can't be detected automatically at
+CSS-authoring time. Fix it by hand instead, after knitting: wrap the
+heading in a fenced div with the `remove-header-space` class and re-knit,
+e.g. `::: \{.remove-header-space\}` then `## My Heading` then `:::` on
+their own lines. Only that heading is affected; every other heading
+keeps its normal spacing.
 }

--- a/man/pdf_report.Rd
+++ b/man/pdf_report.Rd
@@ -53,3 +53,15 @@ An rmd format
 \description{
 Omni Paged PDF Report
 }
+\details{
+Because page breaks depend on where content happens to fall, some layout
+issues only show up after knitting and are best fixed by hand, iteratively,
+rather than automatically. Force a page break with a `\\newpage` on its own
+line. If a `##`/`###`/`####` heading lands at the top of a page (so its
+normal spacing above it looks like too much, with nothing above it on
+that page to visually separate from), wrap just that heading in a fenced
+div with the `remove-header-space` class and re-knit, e.g.
+`::: \{.remove-header-space\}` then `## My Heading` then `:::` on their own
+lines. Only that heading is affected; every other heading keeps its
+normal spacing.
+}


### PR DESCRIPTION
## Background

Following up on the discussion in #266 (documenting why a heading's spacing above it can't be automatically trimmed when it lands at the top of a printed page - that position depends on where content happens to break, which isn't knowable at CSS-authoring time). Rather than an automatic fix, this adds a manual, opt-in one: after knitting, if a heading visibly lands at the top of a page, wrap just that heading and re-knit.

## What I added

A new CSS class in `inst/assets/pdf_report.css`:

```markdown
::: {.remove-header-space}
## My Heading
:::
```

removes only that heading's top margin (`margin-top: 0pt !important` on h1-h4 within the wrapper). Every other heading is unaffected.

Documented in `pdf_report()`'s `@details`.

(Earlier revision of this PR also documented `\newpage` here, since it's another after-the-fact layout fix - dropped that: it's pandoc's own raw-LaTeX page-break recognition, not something this package implements, and documenting it as package behavior overstated what we actually own here.)

## Verification

Forced two headings to the top of a page in a 30-heading test render, wrapped only one of them in `.remove-header-space`, left the other as an unwrapped control, and measured actual PDF text positions with `pdftools::pdf_data()`:
- Wrapped heading: top margin fully removed (flush with the page's normal content top).
- Unwrapped control heading: unchanged.

Also visually confirmed via a rendered page image that the wrapped heading keeps its normal font/color/size and its own spacing *below* it - only the space *above* it changes.

Full test suite passes. Verified `man/pdf_report.Rd` (regenerated for the new `@details`) parses cleanly with `tools::parse_Rd()` and renders as intended with `tools::Rd2txt()` - the `{.remove-header-space}` braces needed escaping to survive Rd's own syntax correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)