### PR TITLE
pdf_report, html_report: fix heading spacing to use the correct Word style

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -45,6 +45,13 @@
   matches the Word brand template (Report Template.dotx). The primary
   heading level (`##`) previously had almost no space below it before body
   text, and the two lower levels had spacing that didn't match Word either.
+* Corrected the heading spacing values from the fix above. They were
+  measured from the Word template's built-in "Heading 1/2/3" styles, which
+  the template doesn't actually use (they render in an unbranded orange, not
+  Omni's navy) - the real reference is the template's custom "Omni Header
+  1/2/3" styles, which give uniform spacing across all three levels rather
+  than the hierarchical spacing the built-in styles have. All three levels
+  (`##`/`###`/`####`) now get the same ~11pt before / ~12pt after spacing.
 
 ## HTML report
 
@@ -63,3 +70,8 @@
   the levels actually used for primary/subtopic/sub-subtopic headings in
   practice; the previous fix had applied each level's spacing one tag too
   high.
+* Corrected the heading spacing values themselves, for the same reason as
+  the PDF report fix above: they were measured from the Word template's
+  unbranded built-in "Heading 1/2/3" styles rather than its custom "Omni
+  Header 1/2/3" styles. All heading levels now get the same ~11pt before /
+  ~12pt after spacing, matching Omni Header 1/2/3's uniform spacing.

--- a/inst/assets/html_report.css
+++ b/inst/assets/html_report.css
@@ -116,27 +116,26 @@ h4:not(#header h4) {
    because of line-height/leading, so these are measured pixel gaps from
    an actual Word-rendered PDF, not the raw docx spacing values.
 
+   Measured from the "Omni Header 1/2/3" custom styles, not the built-in
+   "Heading 1/2/3" styles the template also happens to define - those are
+   an unbranded (orange, not navy) leftover the template never uses.
+   Omni Header 1/2/3 give uniform spacing across all three levels, unlike
+   the built-in styles' hierarchical spacing.
+
    The report-html skeleton starts sections at "##", not "#" - the
    document title comes from YAML front matter, so h1 is never a real
    section heading in practice. h2 is the primary section heading, h3 is
    the subtopic, h4 the sub-subtopic - one level down from what the tag
    name suggests - so these rules target Word's heading levels shifted
-   accordingly (h1 keeps the top-level values in case anyone still uses
-   a bare "#"). */
+   accordingly (h1 keeps the same values in case anyone still uses a bare
+   "#" - Omni Header 1/2/3 are uniform anyway, so there's no level to
+   shift into). */
 h1:not(#header h1),
-h2:not(#header h2) {
-  margin-top: 20pt;
-  margin-bottom: 9pt;
-}
-
-h3:not(#header h3) {
-  margin-top: 11pt;
-  margin-bottom: 8pt;
-}
-
+h2:not(#header h2),
+h3:not(#header h3),
 h4:not(#header h4) {
-  margin-top: 15pt;
-  margin-bottom: 0pt;
+  margin-top: 11pt;
+  margin-bottom: 12pt;
 }
 
 h2 {

--- a/inst/assets/pdf_report.css
+++ b/inst/assets/pdf_report.css
@@ -446,16 +446,16 @@ h1 {
 }
 
 h2 {
-  margin-block-end: 8pt !important;
+  margin-block-end: 11pt !important;
   font-size: 30pt;
   font-weight: 400;
   letter-spacing: 0.03em;
   color: var(--primary-color);
-  margin-top: 18pt !important;
+  margin-top: 9pt !important;
 }
 
 h3 {
-  margin-block-end: 8pt !important;
+  margin-block-end: 11pt !important;
   margin-top: 9pt !important;
   font-size: 16pt;
   font-weight: 400;
@@ -464,8 +464,8 @@ h3 {
 }
 
 h4 {
-  margin-block-end: 0pt !important;
-  margin-top: 13pt !important;
+  margin-block-end: 11pt !important;
+  margin-top: 9pt !important;
   font-size: 13pt;
   font-weight: 400;
   letter-spacing: 0.03em;


### PR DESCRIPTION
## The mistake

Every earlier heading-spacing measurement I did (PDF fix, HTML fix, and the follow-up level-mapping correction) used the Word brand template's **built-in** `Heading 1/2/3` styles via COM automation - literally `$doc.Styles.Item("Heading 3")`, etc. It turns out this template doesn't actually use those: they render in a generic, unbranded orange/rust accent color, not Omni's navy. Every screenshot in this whole effort shows navy headings - because the template's *real* heading styles are a separate custom set: `Omni Header 1/2/3`.

I only caught this because a level-3 heading was rendering with **zero** space below it in the PDF output, and Word's built-in `Heading 3` style genuinely does have ~0pt "after" spacing (verified - that number was correct for the style I measured, I'd just measured the wrong style).

## What I found measuring the correct styles

`Omni Header 1/2/3` give **uniform** spacing across all three levels - not the increasing/hierarchical spacing the built-in styles have:

| | Before | After |
|---|---|---|
| Omni Header 1 (↔ `##`) | ~11pt | ~12pt |
| Omni Header 2 (↔ `###`) | ~11pt | ~12pt |
| Omni Header 3 (↔ `####`) | ~11pt | ~12pt |

Confirmed this holds whether the following paragraph is styled `Normal` or `Omni Body Text` (the template's own wired-in "next style" after any Omni Header - checked its `w:next` attribute in `styles.xml` to be sure this wasn't yet another wrong-style mistake).

## What I changed

- `inst/assets/pdf_report.css`: h2/h3/h4 now all use `margin-top: 9pt` / `margin-block-end: 11pt` (tuned for this pipeline's established rendering offset - same methodology as the original fix).
- `inst/assets/html_report.css`: h1-h4 now all use `margin-top: 11pt` / `margin-bottom: 12pt` directly (no offset needed for this pipeline, per earlier chromote measurements).

## Verification

- PDF: rendered the same before/after test doc used for the original fix, measured actual text positions with `pdftools::pdf_data()` - all three levels land at ~11pt/~12pt (±1pt, consistent with this pipeline's inherent measurement noise throughout this whole effort).
- HTML: measured via a headless Chrome session (`chromote`) - all three levels hit exactly 11pt/12pt.
- Full test suite passes.

## Related but out of scope here

The same built-in-vs-custom-style mismatch could plausibly affect the already-shipped plain-paragraph-spacing fix too (`Normal` vs the template's `Omni Body Text` style) - a quick check found the heading-adjacent gaps are the same either way, but I haven't separately verified plain paragraph-to-paragraph spacing against `Omni Body Text`. Flagging as a possible follow-up, not fixing here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)