### PR TITLE
pdf_report: fix remove-header-space breaking TOC nesting

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -56,10 +56,17 @@
   the normal spacing above a heading looks like too much space there since
   there's nothing above it on that page to separate from, and the renderer
   has no way to detect that position automatically at CSS-authoring time.
-  After knitting, wrap a heading that visibly lands at the top of a page in
-  a fenced div with the new `remove-header-space` class and re-knit:
-  `::: {.remove-header-space}` / `## My Heading` / `:::`. Only that
-  heading's top spacing is removed; every other heading is unaffected.
+  After knitting, add the `remove-header-space` class to a heading that
+  visibly lands at the top of a page and re-knit.
+* Corrected how to apply the `remove-header-space` class from the fix
+  above. It must be added as a header attribute -
+  `## My Heading {.remove-header-space}` - not by wrapping the heading in a
+  fenced div (`::: {.remove-header-space}` / heading / `:::`), which was
+  the originally documented form. The fenced-div form forces the heading's
+  own section to close immediately after it, orphaning any subsections -
+  and their table-of-contents entries - that should nest inside it as flat
+  siblings instead, breaking the table of contents for the rest of that
+  section.
 
 ## HTML report
 

--- a/R/formats.R
+++ b/R/formats.R
@@ -21,11 +21,14 @@ word_report <- function(...) {
 #' spacing above it looks like too much, with nothing above it on that page
 #' to visually separate from), that position depends on where content
 #' happens to break across pages and can't be detected automatically at
-#' CSS-authoring time. Fix it by hand instead, after knitting: wrap the
-#' heading in a fenced div with the `remove-header-space` class and re-knit,
-#' e.g. `::: \{.remove-header-space\}` then `## My Heading` then `:::` on
-#' their own lines. Only that heading is affected; every other heading
-#' keeps its normal spacing.
+#' CSS-authoring time. Fix it by hand instead, after knitting: add the
+#' `remove-header-space` class as a header attribute and re-knit, e.g.
+#' `## My Heading \{.remove-header-space\}`. Only that heading is affected;
+#' every other heading keeps its normal spacing. Add the class this way,
+#' not by wrapping the heading in a fenced div (`::: \{.remove-header-space\}`
+#' / heading / `:::`) - a fenced div forces the heading's own section to
+#' close immediately after it, which orphans any subsections (and their
+#' table-of-contents entries) that should nest inside it.
 #'
 #' @param main_font Main font
 #' @param secondary_font Secondary font

--- a/inst/assets/pdf_report.css
+++ b/inst/assets/pdf_report.css
@@ -480,13 +480,17 @@ h4 {
    space. There's no way to detect that position automatically at CSS-authoring
    time (it depends on where content happens to break across pages, which
    shifts as content changes), so this is an opt-in, per-heading override:
-   after knitting, if a heading visibly lands at the top of a page, wrap
-   just that heading in a fenced div with this class and re-knit -
-     ::: {.remove-header-space}
-     ## My Heading
-     :::
-   Only that heading's top margin is removed; every other heading's normal
-   spacing is unaffected. */
+   after knitting, if a heading visibly lands at the top of a page, add
+   this class as a header attribute and re-knit -
+     ## My Heading {.remove-header-space}
+   Use the header-attribute form, not a fenced div wrapped around the
+   heading (`::: {.remove-header-space}` / heading / `:::`) - a fenced div
+   forces pandoc to close the heading's own section container right after
+   it, which orphans everything that should nest inside it (subsections,
+   and their entries in the table of contents) as flat siblings instead.
+   The attribute form attaches the class without affecting that structure.
+   Only the heading's own top margin is removed either way; every other
+   heading's normal spacing is unaffected. */
 .remove-header-space h1,
 .remove-header-space h2,
 .remove-header-space h3,

--- a/man/pdf_report.Rd
+++ b/man/pdf_report.Rd
@@ -58,9 +58,12 @@ If a `##`/`###`/`####` heading lands at the top of a page (so its normal
 spacing above it looks like too much, with nothing above it on that page
 to visually separate from), that position depends on where content
 happens to break across pages and can't be detected automatically at
-CSS-authoring time. Fix it by hand instead, after knitting: wrap the
-heading in a fenced div with the `remove-header-space` class and re-knit,
-e.g. `::: \{.remove-header-space\}` then `## My Heading` then `:::` on
-their own lines. Only that heading is affected; every other heading
-keeps its normal spacing.
+CSS-authoring time. Fix it by hand instead, after knitting: add the
+`remove-header-space` class as a header attribute and re-knit, e.g.
+`## My Heading \{.remove-header-space\}`. Only that heading is affected;
+every other heading keeps its normal spacing. Add the class this way,
+not by wrapping the heading in a fenced div (`::: \{.remove-header-space\}`
+/ heading / `:::`) - a fenced div forces the heading's own section to
+close immediately after it, which orphans any subsections (and their
+table-of-contents entries) that should nest inside it.
 }


### PR DESCRIPTION
## Bug report

Reported against a real production report: applying `remove-header-space` to headings that have their own subsections caused those subsections (and their table-of-contents entries) to lose all nesting - everything rendered flat in the TOC.

## Root cause

`remove-header-space`'s documented usage was to wrap the heading in a fenced div:

```markdown
::: {.remove-header-space}
## My Heading
:::
```

This forces pandoc to close the heading's auto-generated section `<div>` immediately after the heading itself, since the fenced div's closing `:::` comes right there. Everything that should nest *inside* that section - subsections, and their TOC entries - becomes a flat sibling instead.

Confirmed with a minimal repro: `## Section A` / `### Subsection A1` (no wrapping) nests correctly in both the TOC and the document body. Wrapping `## Section B` in the documented fenced-div form left `### Subsection B1`/`B2` as flat top-level siblings in both places - reproducing the reported bug exactly.

## Fix

This is a documentation/usage fix, not a CSS change. Pandoc's header-attribute syntax attaches the class directly to the heading without touching section structure:

```markdown
## My Heading {.remove-header-space}
```

This lands the class on the exact same underlying `<div class="section levelN ...">` element the existing CSS already targets - just without forcing it to close early. No CSS changes needed.

## Verification

- Confirmed TOC nesting is preserved with the attribute form (same minimal repro, `Section B`'s subsections now nest correctly).
- Confirmed the spacing removal itself still works: forced a heading to the top of a page with `\newpage`, and the attribute-form heading still lands flush (no leftover top margin), same as the fenced-div form did.
- Updated `inst/assets/pdf_report.css`'s comment and `pdf_report()`'s `@details` to document the attribute form and explicitly warn against the fenced-div form. Verified the regenerated `man/pdf_report.Rd` parses cleanly.
- Full test suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)