### PR TITLE
omni_header: add space above eyebrow and below measure description

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -21,6 +21,13 @@
   Any code resetting `plot.caption` first - including a fix for an unrelated
   title/subtitle theme-merge issue - broke it. `omni_header()` now supplies
   its own style unconditionally, independent of theme order.
+* Fixed the header elements feeling scrunched together: added space above
+  the eyebrow (`top_header`), which previously sat flush against the plot's
+  outer margin, and more room below the measure description (`measure`)
+  before the panel starts. The gap between the eyebrow and the primary
+  finding itself is unchanged - the markdown renderer behind that text box
+  only offers that specific gap in one fixed size, and design feedback was
+  that size reads as too much space.
 
 ## PDF report tables
 

--- a/R/omni_header.R
+++ b/R/omni_header.R
@@ -139,13 +139,19 @@ omni_header <- function(
     ggplot2::theme(
       plot.title.position = "plot",
       plot.caption.position = "plot",
-      # element_textbox_simple (not element_markdown) so long findings wrap to the plot width
+      # element_textbox_simple (not element_markdown) so long findings wrap to the plot width.
+      # margin.t gives the eyebrow (when present) space above it instead of sitting flush
+      # against the plot's outer margin. Deliberately not adding extra space between the
+      # eyebrow and primary finding themselves (they're one HTML string joined by a plain
+      # <br>) - that gap can only be tuned in discrete jumps, not continuously, with the
+      # markdown renderer this textbox uses, and the smallest available jump reads as too
+      # much space per design feedback.
       plot.title = ggtext::element_textbox_simple(
         lineheight = 1.4,
-        margin = ggplot2::margin(b = 14),
+        margin = ggplot2::margin(t = 8, b = 14),
         padding = ggplot2::margin(0, 0, 0, 0)
       ),
-      plot.subtitle = ggplot2::element_text(colour = hex_gray),
+      plot.subtitle = ggplot2::element_text(colour = hex_gray, margin = ggplot2::margin(b = 12)),
       # style is passed explicitly (not inherited from whatever plot.caption
       # element theme_omni() or the caller left behind) so the {.color ...}
       # class markdown built above always resolves, regardless of theme order

--- a/tests/testthat/test-omni_header.R
+++ b/tests/testthat/test-omni_header.R
@@ -54,6 +54,16 @@ test_that("omni_header's caption carries its own marquee style (regression: find
   expect_identical(caption_style, .omni_marquee_style())
 })
 
+test_that("omni_header gives the eyebrow space above it and the measure space below it", {
+  h <- omni_header(
+    primary = "Test finding",
+    top_header = "TOPIC - FY2024",
+    measure = "What is measured"
+  )
+  expect_equal(h[[2]]$plot.title$margin, ggplot2::margin(t = 8, b = 14))
+  expect_equal(h[[2]]$plot.subtitle$margin, ggplot2::margin(b = 12))
+})
+
 test_that("omni_highlight_labels colors only matched labels", {
   labeller <- omni_highlight_labels("North", color = "teal-600")
   out <- labeller(c("North", "South"))


### PR DESCRIPTION
## Feedback

Data-viz team reported the header elements feel scrunched: no space above the eyebrow (`top_header`) before it hits the plot's outer margin, and no room below the measure description (`measure`) before the panel/bars start.

## What I changed

- `plot.title`'s textbox now has `margin(t = 8, b = 14)` (was `margin(b = 14)` only) - adds space above the eyebrow.
- `plot.subtitle` now has `margin(b = 12)` (was unset, falling back to ggplot2's small default) - adds space below the measure line.

## What I deliberately left alone

The gap *between* the eyebrow and the primary finding itself. They're one HTML string joined by a plain `<br>` inside a single `ggtext::element_textbox_simple()`. I spent a while trying to add a small amount of extra space there without disturbing the primary finding's own line spacing when it wraps to two lines - tested double line breaks wrapped in tiny-font spans, explicit `line-height` overrides, and a `<p>`-tag margin approach (which broke text wrapping entirely). Every viable technique converged on the same single fixed-size jump, not a continuously adjustable amount - `gridtext` (the markdown renderer behind this text box) doesn't expose finer control through inline HTML. That fixed jump was tested with the design team and rejected as too much space, so this PR ships without touching that specific gap. A real fix would mean pulling the eyebrow out into its own independently-margined element (`plot.tag` didn't work as a drop-in replacement - it renders as a floating overlay, not a layout-reserving block - so it'd need real work, not a tweak).

## Verification

Rendered a bar-chart repro matching the design team's example content (a horizontal bar chart with an eyebrow, two-line-wrapping headline, measure/subtitle, and caption), before and after, and compared side by side with the design team. Added a regression test asserting the exact margin values on `plot.title` and `plot.subtitle`. Full test suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)