### PR TITLE
Caption fixes: restore quieter typography + left-align under theme_omni()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -28,6 +28,15 @@
   finding itself is unchanged - the markdown renderer behind that text box
   only offers that specific gap in one fixed size, and design feedback was
   that size reads as too much space.
+* Fixed the caption (secondary finding and source/N) rendering larger and
+  bold, heavier than the measure description above it - the reverse of the
+  intended hierarchy. It now renders at the smaller, normal-weight, italic
+  styling `theme_omni()` has always specified for captions. This was a
+  regression from the `finding_keyword` color fix above: passing the shared
+  base style explicitly fixed the color but silently brought the base's own
+  larger, bold typography with it. `theme_omni()` and `omni_header()` now
+  build `plot.caption`'s style from one shared helper, so the two can't
+  drift apart again.
 
 ## PDF report tables
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -37,6 +37,14 @@
   larger, bold typography with it. `theme_omni()` and `omni_header()` now
   build `plot.caption`'s style from one shared helper, so the two can't
   drift apart again.
+* Captions are now left-aligned under `theme_omni()` as well as under
+  `omni_header()`. `theme_omni()` styled the caption's size, weight and
+  italic but never its alignment, leaving ggplot2's right-aligned default -
+  so a chart built with `theme_omni()` alone put source/N bottom-right,
+  while the same chart built through `omni_header()` put it bottom-left.
+  Left is the brand standard. Note this changes existing figures that use
+  `theme_omni()` with a caption but without `omni_header()`: their caption
+  moves from the bottom-right to the bottom-left when re-rendered.
 
 ## PDF report tables
 

--- a/R/omni_header.R
+++ b/R/omni_header.R
@@ -154,11 +154,14 @@ omni_header <- function(
       plot.subtitle = ggplot2::element_text(colour = hex_gray, margin = ggplot2::margin(b = 12)),
       # style is passed explicitly (not inherited from whatever plot.caption
       # element theme_omni() or the caller left behind) so the {.color ...}
-      # class markdown built above always resolves, regardless of theme order
+      # class markdown built above always resolves, regardless of theme order.
+      # It must be the *caption* style, not the shared base: the base is
+      # larger and bold, which would render the secondary finding and
+      # source/N heavier than the subtitle above them.
       plot.caption = marquee::element_marquee(
         hjust = 0,
         colour = hex_gray,
-        style = .omni_marquee_style()
+        style = .omni_caption_style()
       )
     )
   )

--- a/R/theme.R
+++ b/R/theme.R
@@ -118,7 +118,17 @@ theme_omni <- function(
             weight = "normal"
           )
       ),
-      plot.caption = marquee::element_marquee(style = .omni_caption_style()),
+      # hjust = 0 is set explicitly: ggplot2 right-aligns captions by default,
+      # and this theme previously overrode the caption's size, weight and
+      # italic but not its alignment - so a chart built with theme_omni()
+      # alone put source/N bottom-right, while the same chart built through
+      # omni_header() (which sets hjust = 0) put it bottom-left. Left is the
+      # brand standard; both paths now agree regardless of the order they
+      # are applied in.
+      plot.caption = marquee::element_marquee(
+        hjust = 0,
+        style = .omni_caption_style()
+      ),
       plot.margin = margin(
         t = 7,
         r = 7,

--- a/R/theme.R
+++ b/R/theme.R
@@ -36,6 +36,30 @@
   )
 }
 
+#' Build the marquee style for caption text
+#'
+#' [.omni_marquee_style()] with the caption's quieter typography layered on
+#' top: smaller, normal weight, italic. The caption sits below the plot and
+#' must read as subordinate to the subtitle above it, so it must not inherit
+#' the shared base's larger bold setting.
+#'
+#' Both [theme_omni()] and [omni_header()] set `plot.caption` themselves, and
+#' each must pass a fully-specified style rather than relying on ggplot2's
+#' theme-merge to backfill one from the other (see [.omni_marquee_style()]).
+#' They share this helper so the two can't drift apart - they have twice
+#' before, once on color and once on size/weight.
+#'
+#' @noRd
+.omni_caption_style <- function() {
+  .omni_marquee_style() |>
+    marquee::modify_style(
+      "base",
+      size = 12,
+      weight = "normal",
+      italic = TRUE
+    )
+}
+
 #' OMNI Institute ggplot2 theme
 #'
 #' @description Applies the OMNI Institute theme to the plot.
@@ -94,15 +118,7 @@ theme_omni <- function(
             weight = "normal"
           )
       ),
-      plot.caption = marquee::element_marquee(
-        style = omni_style |>
-          marquee::modify_style(
-            "base",
-            size = 12,
-            weight = "normal",
-            italic = TRUE
-          )
-      ),
+      plot.caption = marquee::element_marquee(style = .omni_caption_style()),
       plot.margin = margin(
         t = 7,
         r = 7,

--- a/tests/testthat/test-omni_header.R
+++ b/tests/testthat/test-omni_header.R
@@ -82,6 +82,23 @@ test_that("theme_omni and omni_header agree on caption styling", {
   )
 })
 
+test_that("the caption is left-aligned no matter which order the theme is applied in", {
+  # ggplot2 right-aligns captions by default. theme_omni() styled the
+  # caption's text but not its alignment, so source/N landed bottom-right
+  # via theme_omni() alone and bottom-left via omni_header() - the same
+  # chart differing on the order two lines were written in.
+  hdr <- omni_header(primary = "x", finding = "y", source = "s", n = 1)
+  base <- ggplot2::ggplot(mtcars, ggplot2::aes(wt, mpg)) + ggplot2::geom_point()
+
+  caption_hjust <- function(p) {
+    ggplot2::ggplot_build(p)$plot$theme$plot.caption$hjust
+  }
+
+  expect_equal(caption_hjust(base + theme_omni() + hdr), 0)
+  expect_equal(caption_hjust(base + hdr + theme_omni()), 0)
+  expect_equal(caption_hjust(base + theme_omni()), 0)
+})
+
 test_that("omni_header gives the eyebrow space above it and the measure space below it", {
   h <- omni_header(
     primary = "Test finding",

--- a/tests/testthat/test-omni_header.R
+++ b/tests/testthat/test-omni_header.R
@@ -51,7 +51,35 @@ test_that("omni_header's caption carries its own marquee style (regression: find
   )
   caption_style <- h[[2]]$plot.caption$style
   expect_false(is.null(caption_style))
-  expect_identical(caption_style, .omni_marquee_style())
+  expect_identical(caption_style, .omni_caption_style())
+})
+
+test_that("omni_header's caption is quieter than the subtitle, not louder", {
+  # The caption sits below the plot and must read as subordinate to the
+  # subtitle above it. The shared base style (.omni_marquee_style()) is
+  # larger and bold, so passing it straight through renders the secondary
+  # finding and source/N heavier than the subtitle - the reverse of the
+  # intended hierarchy. Regression: the fix for the finding_keyword color
+  # bug started passing the base style explicitly and silently took the
+  # caption's own size/weight/italic with it.
+  h <- omni_header(
+    primary = "Test finding",
+    finding = "A second point",
+    finding_keyword = "second"
+  )
+  base <- unclass(h[[2]]$plot.caption$style)[[1]]$base
+  expect_equal(base$size, 12)
+  expect_equal(base$weight, 400) # normal, not 700/bold
+  expect_true(base$italic)
+})
+
+test_that("theme_omni and omni_header agree on caption styling", {
+  # These two set plot.caption independently; they have drifted apart twice
+  # (once on color, once on size/weight). Same helper, same result.
+  expect_identical(
+    theme_omni()$plot.caption$style,
+    omni_header(primary = "x", finding = "y")[[2]]$plot.caption$style
+  )
 })
 
 test_that("omni_header gives the eyebrow space above it and the measure space below it", {


### PR DESCRIPTION
Two fixes to `plot.caption`, the theme slot `theme_omni()` and `omni_header()` both set independently - and have now drifted apart on **three** separate properties.

---

## 1. Caption renders bold and oversized (regression from #267)

The caption - secondary finding + source/N - rendered at size 13 **bold**, heavier and larger than the measure description above it. The reverse of the intended hierarchy; the caption should be the quietest element on the chart.

**Root cause, and it's mine.** Before #267, `omni_header()` set `plot.caption` with no `style`, so ggplot2's theme-merge backfilled `theme_omni()`'s - which carried the color tags *and* the caption's size/weight/italic. #267 fixed the `finding_keyword`-renders-gray bug by passing `.omni_marquee_style()` explicitly, so color stopped depending on merge order. But that's the *shared base* (size 13, bold) - the explicit pass fixed the color and silently took the base's typography with it.

Confirmed numerically: the #267 regression test now fails with exactly

```
`actual$base$size`:   12.0   `expected$base$size`:   13.0
`actual$base$weight`: 400    `expected$base$weight`: 700
`actual$base$italic`: TRUE   `expected$base$italic`: FALSE
```

**Fix:** new `.omni_caption_style()` - shared base plus the caption's own size/weight/italic - used by **both** functions.

## 2. Caption right-aligned under `theme_omni()`

Found while investigating a separate (unreproducible) report. ggplot2 right-aligns captions by default; `theme_omni()` overrode the caption's size, weight and italic but never its alignment. `omni_header()` sets `hjust = 0`. So the same chart put source/N bottom-right or bottom-left depending on which was applied last.

Left is the brand standard, and styling everything about the caption *except* alignment reads as an oversight rather than a decision.

**Behavior change:** figures using `theme_omni()` with a caption but **without** `omni_header()` move their caption bottom-right → bottom-left when re-rendered. Anything built through `omni_header()` - including everything the data viz tool generates - is unaffected; it was already left-aligned.

---

## Verification

- Rendered the same chart before/after: caption goes from bold and larger-than-subtitle to smaller, normal-weight, italic, with the #267 `finding_keyword` color still resolving (checked with a non-default highlight color).
- Caption `hjust` now resolves to `0` in all four theme-application orders (previously `1` in two of them).
- Tests: updated the #267 assertion to the new helper; added three - one pinning the caption's actual size/weight/italic, one asserting `theme_omni()` and `omni_header()` produce identical caption styles, one asserting left-alignment across theme orders. Full suite passes.

## Related, not here

`omni_highlight_labels()` silently defaulting its color to orange-red is confirmed and goes out separately, since it's a breaking API change and should be revertible on its own. A reported centered-subtitle issue did not reproduce - subtitle resolves to `hjust = 0` in every order tested - so it needs a repro before any change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)