### PR TITLE
omni_highlight_labels(): require color instead of silently defaulting it (breaking)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -29,6 +29,19 @@
   only offers that specific gap in one fixed size, and design feedback was
   that size reads as too much space.
 
+## omni_highlight_labels()
+
+* **Breaking:** `color` is now required instead of defaulting to
+  `"orange-red-600"`. A chart uses one highlight color and the colored axis
+  label has to match the bar or point it labels, but the default silently
+  produced an orange-red label on charts highlighted in any other color -
+  a brand violation with nothing in the rendered output to flag it, and
+  invisible to anyone using a tool that writes the call for them. Omitting
+  `color` now raises an error naming the fix. Update existing calls by
+  passing the same color given to `omni_header()`; calls that were relying
+  on the default and are genuinely orange-red charts need
+  `color = "orange-red-600"` added.
+
 ## PDF report tables
 
 * Table columns no longer change width where a table breaks across pages.

--- a/R/omni_header.R
+++ b/R/omni_header.R
@@ -222,8 +222,16 @@ omni_baseline <- function(
 #' the chart gray, e.g.
 #' `theme(axis.text.y.left = ggtext::element_markdown(colour = omni_colors("chart-gray")))`.
 #'
+#' `color` is required, deliberately. A chart uses one highlight color, and the
+#' colored axis label has to be that same color - it is labelling the bar or point
+#' it sits next to. A default here would silently produce a label in one color and
+#' a bar in another whenever the chart's highlight isn't the default, which is a
+#' brand violation nothing in the rendered output flags. Pass the same color given
+#' to [omni_header()].
+#'
 #' @param highlight One or more category labels to color.
-#' @param color The highlight color name.
+#' @param color Required. The chart's highlight color name - the same one passed to
+#'   [omni_header()].
 #'
 #' @return A function suitable for the `labels` argument of a discrete scale.
 #' @export
@@ -232,8 +240,19 @@ omni_baseline <- function(
 #' library(ggplot2)
 #' ggplot(mtcars, aes(mpg, rownames(mtcars))) +
 #'   geom_point() +
-#'   scale_y_discrete(labels = omni_highlight_labels("Valiant"))
-omni_highlight_labels <- function(highlight, color = "orange-red-600") {
+#'   scale_y_discrete(
+#'     labels = omni_highlight_labels("Valiant", color = "orange-red-600")
+#'   )
+omni_highlight_labels <- function(highlight, color = NULL) {
+  if (is.null(color)) {
+    cli::cli_abort(c(
+      "{.arg color} is required.",
+      "i" = "Pass the chart's highlight color - the same one given to
+             {.fn omni_header} - so the label matches the bar or point it
+             labels.",
+      ">" = '{.code omni_highlight_labels("Denver", color = "periwinkle-600")}'
+    ))
+  }
   hex <- omni_colors(color)
   function(lbls) {
     out <- as.character(lbls)

--- a/man/omni_highlight_labels.Rd
+++ b/man/omni_highlight_labels.Rd
@@ -4,12 +4,13 @@
 \alias{omni_highlight_labels}
 \title{Highlight a category label}
 \usage{
-omni_highlight_labels(highlight, color = "orange-red-600")
+omni_highlight_labels(highlight, color = NULL)
 }
 \arguments{
 \item{highlight}{One or more category labels to color.}
 
-\item{color}{The highlight color name.}
+\item{color}{Required. The chart's highlight color name - the same one passed to
+[omni_header()].}
 }
 \value{
 A function suitable for the `labels` argument of a discrete scale.
@@ -20,9 +21,19 @@ Returns a labelling function (for `scale_*_discrete(labels = ...)`) that wraps a
 the chart gray, e.g.
 `theme(axis.text.y.left = ggtext::element_markdown(colour = omni_colors("chart-gray")))`.
 }
+\details{
+`color` is required, deliberately. A chart uses one highlight color, and the
+colored axis label has to be that same color - it is labelling the bar or point
+it sits next to. A default here would silently produce a label in one color and
+a bar in another whenever the chart's highlight isn't the default, which is a
+brand violation nothing in the rendered output flags. Pass the same color given
+to [omni_header()].
+}
 \examples{
 library(ggplot2)
 ggplot(mtcars, aes(mpg, rownames(mtcars))) +
   geom_point() +
-  scale_y_discrete(labels = omni_highlight_labels("Valiant"))
+  scale_y_discrete(
+    labels = omni_highlight_labels("Valiant", color = "orange-red-600")
+  )
 }

--- a/tests/testthat/test-omni_header.R
+++ b/tests/testthat/test-omni_header.R
@@ -71,6 +71,14 @@ test_that("omni_highlight_labels colors only matched labels", {
   expect_equal(out[2], "South")
 })
 
+test_that("omni_highlight_labels requires color rather than defaulting it", {
+  # A default silently produced an orange-red axis label on a chart whose
+  # bars and title keyword were some other highlight color - a brand
+  # violation with nothing in the output to flag it, and invisible to
+  # anyone using a tool that generates the call for them.
+  expect_error(omni_highlight_labels("North"), "`color` is required")
+})
+
 test_that("omni_baseline returns a ggplot layer", {
   expect_s3_class(omni_baseline(n = 5), "ggproto")
 })


### PR DESCRIPTION
> **Breaking change.** Calls that omit `color` now error. See migration below.

## Bug (confirmed)

`omni_highlight_labels(highlight, color = "orange-red-600")` defaulted its color. But a chart uses **one** highlight color, and the colored axis label has to be that color — it labels the bar or point it sits beside.

So any chart highlighted in something other than orange-red got a mismatched label. Rendered proof, with `color = "periwinkle-600"` passed to `omni_header()` and the labeller called without `color`:

- bar → periwinkle
- title keyword → periwinkle
- **axis label → orange-red**

Nothing in the output flags it. And the people the data viz tool is built for — who by design "don't need to open or even see the R code" — have no way to know the label is wrong rather than intentional emphasis. It's a brand violation produced by the tooling meant to prevent brand violations.

It also evades testing: the gallery recipe's own highlight happens to be orange-red, so the recipe can never surface it. It only appears once someone picks a non-default color, which is exactly when nobody is looking for it.

## Fix

`color` is now required. Omitting it raises:

```
Error: `color` is required.
i Pass the chart's highlight color - the same one given to `omni_header()` -
  so the label matches the bar or point it labels.
> `omni_highlight_labels("Denver", color = "periwinkle-600")`
```

## Why breaking rather than documenting

Documentation reaches R users. It does not reach the tool's end users, and it's an unreliable constraint on a code generator — the mismatch would stay silent.

And it's cheap right now: the function was added **2026-07-10, about a month ago**. The only caller in this repo besides its own `@examples` is a test that already passes `color` explicitly. The data viz tool already has the value to pass — it hands the same color to `omni_header()`. This is the cheapest this fix will ever be; adoption only grows.

## Migration

Pass the same color you give `omni_header()`:

```r
# before
scale_y_discrete(labels = omni_highlight_labels("Denver"))

# after
scale_y_discrete(labels = omni_highlight_labels("Denver", color = "periwinkle-600"))
```

Calls that were relying on the default *and* are genuinely orange-red charts just need `color = "orange-red-600"` added — no visual change.

## Verification

Error path and happy path both exercised directly; `@examples` updated to pass `color` so it models correct usage; test added asserting the error. Full suite passes.

Separate from the two caption fixes in #276 so either can be reverted independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)