### PR TITLE
set_omni_defaults(): default data marks to a 600 colour, not the chart gray

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -46,7 +46,8 @@ Suggests:
     gghighlight,
     scales,
     testthat (>= 3.0.0),
-    tidyverse
+    tidyverse,
+    withr
 VignetteBuilder: 
     knitr
 Author: c( person("Thomas", "Vroylandt", email =

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,28 @@
   four add olive-green), and the scale errors clearly when more categories than
   palette colors are requested (#242).
 
+## Chart defaults
+
+* **Breaking-ish:** data marks now default to a 600-level brand colour
+  (`periwinkle-600`) instead of the chart gray. `set_omni_defaults()` was
+  setting every bar, column, point, line, boxplot, density and violin - and
+  the matching stat defaults - to `chart-gray`, so any chart that did not
+  call out a single group came out entirely gray. The guidance is that the
+  chart gray is for de-emphasising the *other* groups when one group is
+  highlighted, not for the whole chart.
+* `set_omni_defaults()`'s `base_color` argument is renamed `primary_color`,
+  which better describes what it does, and now accepts a brand colour name
+  (`"orange-red-600"`) as well as a hex. `base_color` still works and warns.
+  Same for `set_client_defaults()`, whose client blue is unchanged.
+* Documented that switching the colour part-way through a report by calling
+  `set_omni_defaults()` again is unsafe: `update_geom_defaults()` resolves
+  when a plot is *drawn*, not when it is built, so a second call repaints
+  every plot object that has not been printed yet - a report that builds
+  figures into a list or saves them at the end would silently get the last
+  colour for all of them. To vary the colour per figure, set it on the geom
+  (`geom_col(fill = omni_colors("orange-red-600"))`), which is captured when
+  the layer is created.
+
 ## omni_header()
 
 * Fixed `finding_keyword` (the secondary-finding stripe/text in the caption)

--- a/R/ggplot_defaults.R
+++ b/R/ggplot_defaults.R
@@ -1,8 +1,55 @@
+#' Resolve a primary colour argument to a hex string
+#'
+#' Accepts a brand colour name (`"periwinkle-600"`) or a literal hex, so
+#' [set_client_defaults()] can keep passing a non-brand client colour. Also
+#' carries the `base_color` deprecation.
+#'
+#' @noRd
+.resolve_primary_color <- function(primary_color, base_color, fn) {
+  if (!is.null(base_color)) {
+    cli::cli_warn(c(
+      "!" = "{.arg base_color} is deprecated in {.fn {fn}}; use {.arg primary_color}.",
+      "i" = "It sets the chart's primary data colour, which now defaults to
+             {.val periwinkle-600} rather than the old chart gray."
+    ))
+    primary_color <- base_color
+  }
+  if (grepl("^#[0-9A-Fa-f]{6}$", primary_color)) {
+    unname(primary_color)
+  } else {
+    unname(omni_colors(primary_color))
+  }
+}
+
 #' Update defaults to OMNI's theme
 #'
+#' @details
+#' `primary_color` is the colour of the data itself - bars, points, lines,
+#' boxplots and their stat equivalents - for charts that do not call out one
+#' group. Per the data viz guidance that is a 600-level brand colour, not the
+#' chart gray, which is reserved for de-emphasising the *other* groups when one
+#' group is highlighted.
+#'
+#' To use a different colour for one figure, set it on the geom rather than
+#' calling this function again:
+#'
+#' ```r
+#' geom_col(fill = omni_colors("orange-red-600"))
+#' ```
+#'
+#' That is not just a style preference. `ggplot2::update_geom_defaults()`,
+#' which this function uses, is resolved when a plot is *drawn*, not when it is
+#' built - so calling `set_omni_defaults()` a second time repaints every plot
+#' object that has not been printed yet. A report that builds figures into a
+#' list, patchworks them, or saves them at the end would silently get the last
+#' colour set for all of them. A colour passed to the geom is captured when the
+#' layer is created and is immune to that.
 #'
 #' @param base_family The base font family for the theme.
-#' @param base_color Base color
+#' @param primary_color The chart's primary data colour: a brand colour name
+#'   such as `"periwinkle-600"`, or a hex string. Defaults to
+#'   `"periwinkle-600"`.
+#' @param base_color Deprecated. Use `primary_color`.
 #'
 #' @import ggplot2
 #' @import ggrepel
@@ -10,8 +57,10 @@
 #' @export
 set_omni_defaults <- function(
   base_family = "Inter Tight",
-  base_color = omni_colors("chart-gray")
+  primary_color = "periwinkle-600",
+  base_color = NULL
 ) {
+  base_color <- .resolve_primary_color(primary_color, base_color, "set_omni_defaults")
   # set default theme -----------------------------------------------------
 
   ggplot2::theme_set(omni::theme_omni(
@@ -151,7 +200,9 @@ ggplot_defaults <- function() {
 #'
 #'
 #' @param base_family The base font family for the theme.
-#' @param base_color Base color
+#' @param primary_color The chart's primary data colour: a brand colour name or
+#'   a hex string. Defaults to the client blue, `"#405065"`.
+#' @param base_color Deprecated. Use `primary_color`.
 #'
 #' @import ggplot2
 #' @import ggrepel
@@ -159,10 +210,16 @@ ggplot_defaults <- function() {
 #' @export
 set_client_defaults <- function(
   base_family = "Inter Tight",
-  base_color = "#405065"
+  primary_color = "#405065",
+  base_color = NULL
 ) {
+  primary_color <- .resolve_primary_color(
+    primary_color,
+    base_color,
+    "set_client_defaults"
+  )
   set_omni_defaults(
     base_family = base_family,
-    base_color = base_color
+    primary_color = primary_color
   )
 }

--- a/man/set_client_defaults.Rd
+++ b/man/set_client_defaults.Rd
@@ -4,12 +4,19 @@
 \alias{set_client_defaults}
 \title{Update defaults to OMNI's client theme}
 \usage{
-set_client_defaults(base_family = "Inter Tight", base_color = "#405065")
+set_client_defaults(
+  base_family = "Inter Tight",
+  primary_color = "#405065",
+  base_color = NULL
+)
 }
 \arguments{
 \item{base_family}{The base font family for the theme.}
 
-\item{base_color}{Base color}
+\item{primary_color}{The chart's primary data colour: a brand colour name or
+a hex string. Defaults to the client blue, `"#405065"`.}
+
+\item{base_color}{Deprecated. Use `primary_color`.}
 }
 \description{
 Update defaults to OMNI's client theme

--- a/man/set_omni_defaults.Rd
+++ b/man/set_omni_defaults.Rd
@@ -6,14 +6,41 @@
 \usage{
 set_omni_defaults(
   base_family = "Inter Tight",
-  base_color = omni_colors("chart-gray")
+  primary_color = "periwinkle-600",
+  base_color = NULL
 )
 }
 \arguments{
 \item{base_family}{The base font family for the theme.}
 
-\item{base_color}{Base color}
+\item{primary_color}{The chart's primary data colour: a brand colour name
+such as `"periwinkle-600"`, or a hex string. Defaults to
+`"periwinkle-600"`.}
+
+\item{base_color}{Deprecated. Use `primary_color`.}
 }
 \description{
 Update defaults to OMNI's theme
+}
+\details{
+`primary_color` is the colour of the data itself - bars, points, lines,
+boxplots and their stat equivalents - for charts that do not call out one
+group. Per the data viz guidance that is a 600-level brand colour, not the
+chart gray, which is reserved for de-emphasising the *other* groups when one
+group is highlighted.
+
+To use a different colour for one figure, set it on the geom rather than
+calling this function again:
+
+```r
+geom_col(fill = omni_colors("orange-red-600"))
+```
+
+That is not just a style preference. `ggplot2::update_geom_defaults()`,
+which this function uses, is resolved when a plot is *drawn*, not when it is
+built - so calling `set_omni_defaults()` a second time repaints every plot
+object that has not been printed yet. A report that builds figures into a
+list, patchworks them, or saves them at the end would silently get the last
+colour set for all of them. A colour passed to the geom is captured when the
+layer is created and is immune to that.
 }

--- a/tests/testthat/test-ggplot_defaults.R
+++ b/tests/testthat/test-ggplot_defaults.R
@@ -1,0 +1,57 @@
+# set_omni_defaults() mutates global ggplot2 geom/stat defaults, so each test
+# restores what it found. Without this a failure here would silently change the
+# colours every later test renders with.
+local_geom_defaults <- function(env = parent.frame()) {
+  before <- list(
+    col = ggplot2::GeomCol$default_aes$fill,
+    point = ggplot2::GeomPoint$default_aes$colour,
+    count = ggplot2::StatCount$default_aes$fill
+  )
+  withr::defer(
+    {
+      ggplot2::update_geom_defaults("col", list(fill = before$col))
+      ggplot2::update_geom_defaults("point", list(colour = before$point))
+      ggplot2::update_stat_defaults("count", list(fill = before$count))
+    },
+    envir = env
+  )
+}
+
+test_that("data marks default to a 600 brand colour, not the chart gray", {
+  # The guidance is that a chart with no highlighted group is drawn in one
+  # 600-level colour. The old default was chart-gray, which is meant for
+  # de-emphasising the other groups *when* one group is highlighted - so every
+  # unhighlighted chart came out entirely gray.
+  local_geom_defaults()
+  set_omni_defaults()
+  expect_equal(ggplot2::GeomCol$default_aes$fill, unname(omni_colors("periwinkle-600")))
+  expect_false(ggplot2::GeomCol$default_aes$fill == unname(omni_colors("chart-gray")))
+})
+
+test_that("primary_color accepts a brand name or a hex, and reaches stats too", {
+  local_geom_defaults()
+
+  set_omni_defaults(primary_color = "orange-red-600")
+  expect_equal(ggplot2::GeomCol$default_aes$fill, unname(omni_colors("orange-red-600")))
+  expect_equal(ggplot2::GeomPoint$default_aes$colour, unname(omni_colors("orange-red-600")))
+  # stat defaults must move with the geoms or stat_count bars drift out of sync
+  expect_equal(ggplot2::StatCount$default_aes$fill, unname(omni_colors("orange-red-600")))
+
+  set_omni_defaults(primary_color = "#123456")
+  expect_equal(ggplot2::GeomCol$default_aes$fill, "#123456")
+})
+
+test_that("base_color still works but warns", {
+  local_geom_defaults()
+  expect_warning(
+    set_omni_defaults(base_color = omni_colors("plum-600")),
+    "deprecated"
+  )
+  expect_equal(ggplot2::GeomCol$default_aes$fill, unname(omni_colors("plum-600")))
+})
+
+test_that("set_client_defaults keeps its client colour", {
+  local_geom_defaults()
+  set_client_defaults()
+  expect_equal(ggplot2::GeomCol$default_aes$fill, "#405065")
+})


### PR DESCRIPTION
## The bug

`set_omni_defaults()` set every data mark to `chart-gray`:

```r
set_omni_defaults(base_family = "Inter Tight", base_color = omni_colors("chart-gray"))
...
update_geom_defaults("bar",  list(fill = base_color))
update_geom_defaults("col",  list(fill = base_color))
update_geom_defaults("point", list(colour = base_color))   # + line, step, path, boxplot, density, violin
update_stat_defaults("count", list(fill = base_color))     # + boxplot, density, ydensity
```

So a plain `geom_col()` with no fill mapping - a chart with no highlighted group - came out **entirely gray**. Per the data viz guidance an unhighlighted chart is drawn in one 600-level brand colour; the chart gray is for de-emphasising the *other* groups when one group is highlighted. The data viz tool team was correcting this by hand on every figure.

## The change

- Data marks now default to **`periwinkle-600`** - first colour in the package's own categorical palette, and distinct from `orange-red-600`, which `omni_header()` uses as the highlight colour, so "single colour" and "highlighted" stay visually distinct.
- `base_color` → **`primary_color`**, which describes what it actually drives, and now takes a brand colour name (`"orange-red-600"`) as well as a hex, so it reads the same way as `omni_header(color=)` and `omni_highlight_labels(color=)`. `base_color` still works and warns.
- `set_client_defaults()` gets the same rename; its client blue `#405065` is unchanged.

## A trap worth knowing about, now documented

The original ask was to be able to switch colour part-way through a long report - orange-red for agency figures, periwinkle for demographics - by calling the setter again. **That is not safe, and I tested it rather than assuming.** Built a plot under periwinkle, switched the default to orange-red, then rendered both:

```
plot A (built under periwinkle, rendered after switch): #CC4100   <- orange-red
plot B (built under orange-red):                        #CC4100
```

`update_geom_defaults()` resolves when a plot is **drawn**, not when it is built. So a second call repaints every plot object not yet printed. In an Rmd where each chunk builds and prints immediately it usually works; the moment a report collects figures in a list, patchworks them, or saves at the end, every figure silently takes the last colour set.

Per-figure colour therefore belongs on the geom, where it is captured at layer creation and is immune to later changes:

```r
geom_col(fill = omni_colors("orange-red-600"))
```

Both the trap and the recommendation are in `?set_omni_defaults`.

## Verification

Checked default, brand-name override, hex override, the deprecation path, `set_client_defaults()`, and that stat defaults move with the geoms. Rendered the tool's own gender chart under gray / periwinkle / orange-red for comparison.

Four tests added, each restoring the global geom and stat defaults it touches so a failure here cannot silently recolour later tests. Full suite: 45 pass.

## Deliberately not changed

`omni_highlight_labels()` still requires an explicit `color` rather than defaulting to the primary. In exactly the per-figure-override case above the geom fill is set per plot, so a global-tracking default would drift out of sync again - which is the bug #277 made it explicit to prevent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)