### PR TITLE
omni_span(): emit the class-based tag so the colour actually applies

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -81,7 +81,6 @@
   Left is the brand standard. Note this changes existing figures that use
   `theme_omni()` with a caption but without `omni_header()`: their caption
   moves from the bottom-right to the bottom-left when re-rendered.
-
 * Fixed the primary finding rendering in `theme_omni()`'s title gray
   (`#666665`) instead of navy. `omni_header()` set `plot.title`'s style but
   not its `colour`, and `element_marquee()`'s own `colour` overrides the
@@ -90,19 +89,6 @@
   unaffected (it is a tag, which overrides the base), which is part of why
   this survived review. Third instance of one shape: an element built
   without being fully specified inheriting stale state from `theme_omni()`.
-
-## omni_highlight_labels()
-
-* **Breaking:** `color` is now required instead of defaulting to
-  `"orange-red-600"`. A chart uses one highlight color and the colored axis
-  label has to match the bar or point it labels, but the default silently
-  produced an orange-red label on charts highlighted in any other color -
-  a brand violation with nothing in the rendered output to flag it, and
-  invisible to anyone using a tool that writes the call for them. Omitting
-  `color` now raises an error naming the fix. Update existing calls by
-  passing the same color given to `omni_header()`; calls that were relying
-  on the default and are genuinely orange-red charts need
-  `color = "orange-red-600"` added.
 
 * Tightened the header's vertical rhythm against design feedback that the
   elements sat too far apart: the gap between the primary finding and the
@@ -131,6 +117,19 @@
   that an HTML span passed into `primary` now renders as *uncolored* text
   rather than erroring, so any hand-written `<span>` in a header needs
   converting.
+
+## omni_highlight_labels()
+
+* **Breaking:** `color` is now required instead of defaulting to
+  `"orange-red-600"`. A chart uses one highlight color and the colored axis
+  label has to match the bar or point it labels, but the default silently
+  produced an orange-red label on charts highlighted in any other color -
+  a brand violation with nothing in the rendered output to flag it, and
+  invisible to anyone using a tool that writes the call for them. Omitting
+  `color` now raises an error naming the fix. Update existing calls by
+  passing the same color given to `omni_header()`; calls that were relying
+  on the default and are genuinely orange-red charts need
+  `color = "orange-red-600"` added.
 
 ## PDF report tables
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,20 @@
   four add olive-green), and the scale errors clearly when more categories than
   palette colors are requested (#242).
 
+## omni_span()
+
+* Fixed the colour never applying. `omni_span()` built a raw-hex marquee tag
+  by prefixing `"{#"` and then interpolating `omni_colors()`, which already
+  returns a leading `#` - so it emitted `{##5776B2 Housing}`, which marquee
+  cannot parse. The phrase rendered in the base colour with no error and no
+  warning. It now emits the class-based tag, `{.periwinkle-600 Housing}`,
+  which is what `omni_header()`'s own documentation already described and
+  what `keyword` and `finding_keyword` have always used internally - one
+  resolution path for every coloured phrase in the header instead of two.
+* `omni_span()` now errors on a colour name that is not a brand colour.
+  Previously an unknown name produced an unregistered tag, which fails the
+  same silent way the malformed hex did.
+
 ## Chart defaults
 
 * **Breaking-ish:** data marks now default to a 600-level brand colour

--- a/R/omni_header.R
+++ b/R/omni_header.R
@@ -366,7 +366,20 @@ omni_highlight_labels <- function(highlight, color = NULL) {
 #' @examples
 #' stringr::str_glue("{omni_span('Housing', 'periwinkle-600')} led the requests")
 omni_span <- function(text, color) {
+  # Emit the class-based tag, matching what .wrap_first() already uses for
+  # `keyword` and `finding_keyword`, so every coloured phrase in the header
+  # resolves through the one path registered by .omni_marquee_style().
+  #
+  # The previous raw-hex form built "{#" and then interpolated omni_colors(),
+  # which itself returns a leading "#" - emitting "{##5776B2 Housing}", which
+  # marquee cannot parse. It renders the phrase in the base colour with no
+  # error and no warning, so nothing but a parsed or rendered check catches it.
+  #
+  # omni_colors() is called purely to validate: an unknown colour name errors
+  # here instead of emitting an unregistered tag, which would fail the same
+  # silent way the malformed hex did.
+  omni_colors(color)
   as.character(
-    stringr::str_glue("{{#{omni_colors(color)} {text}}}")
+    stringr::str_glue("{{.{color} {text}}}")
   )
 }

--- a/tests/testthat/test-omni_header.R
+++ b/tests/testthat/test-omni_header.R
@@ -7,8 +7,50 @@ test_that("chart-gray replaces the old two-gray split", {
 test_that("omni_span wraps text in a colored span", {
   out <- omni_span("Housing", "periwinkle-600")
   expect_type(out, "character")
-  expect_match(out, omni_colors("periwinkle-600"), fixed = TRUE)
-  expect_match(out, "Housing", fixed = TRUE)
+  expect_equal(out, "{.periwinkle-600 Housing}")
+})
+
+test_that("omni_span rejects a colour name that is not a brand colour", {
+  # Without this the tag would simply be unregistered and the phrase would
+  # render in the base colour - silently, like every other marquee colour
+  # failure in this file.
+  expect_error(omni_span("Housing", "not-a-colour"))
+})
+
+# Every coloured phrase in the header resolves through a marquee tag, and when
+# a tag is malformed or unregistered marquee emits no error and no warning - it
+# just draws the base colour. Asserting on the *string* is not enough: the
+# previous omni_span() built "{##5776B2 Housing}" (omni_colors() already
+# returns a leading "#"), which still contained the hex and so passed a
+# substring check while rendering navy. These parse the markup the same way the
+# renderer does and assert the colour actually resolves.
+resolved_colour <- function(md, phrase) {
+  parsed <- marquee::marquee_parse(md, style = .omni_marquee_style())
+  # contains, not equals: the finding keyword's node also carries the stripe
+  # glyph ("▌ Housing"), so an exact match would miss it
+  row <- parsed[grepl(phrase, parsed$text, fixed = TRUE), ]
+  if (!nrow(row)) return(NA_character_)
+  row$color[1]
+}
+
+test_that("omni_span's colour resolves when the markup is parsed", {
+  md <- paste(omni_span("Housing", "plum-600"), "led the requests")
+  expect_equal(resolved_colour(md, "Housing"), unname(omni_colors("plum-600")))
+})
+
+test_that("the title keyword's colour resolves when the markup is parsed", {
+  h <- omni_header(primary = "Housing led", keyword = "Housing", color = "teal-600")
+  expect_equal(resolved_colour(h[[1]]$title, "Housing"), unname(omni_colors("teal-600")))
+})
+
+test_that("the finding keyword's colour resolves when the markup is parsed", {
+  h <- omni_header(
+    primary = "x",
+    finding = "Housing led the requests",
+    finding_keyword = "Housing",
+    color = "olive-green-600"
+  )
+  expect_equal(resolved_colour(h[[1]]$caption, "Housing"), unname(omni_colors("olive-green-600")))
 })
 
 test_that("omni_header returns labs + theme components", {


### PR DESCRIPTION
Reported from data viz tool testing (butterfly chart, two-series title). **The main defect is real and is mine** - introduced in #278 when `omni_span()` was switched from HTML to marquee markup. One secondary claim in the report doesn't reproduce; details below since it affects what to re-test.

## Confirmed: the colour never applied

`omni_span()` built a raw-hex tag as `"{#"` plus `omni_colors()` - but `omni_colors()` already returns a leading `#`, so it emitted:

```
{##5776B2 Housing}
```

marquee can't parse that. Verified at both levels:

| markup | parsed colour | rendered |
|---|---|---|
| `{##5776B2 Housing}` | `black` | navy only - no periwinkle |
| `{.periwinkle-600 Housing}` | `#5776B2` | correct |

No error, no warning - the phrase just draws in the base colour.

## Fix

Emit the class-based tag, which is what `omni_header()`'s own documentation already described (*"a brand color name in braces colors a phrase directly ... which is what `omni_span()` produces"*) and what `.wrap_first()` has always used for `keyword` and `finding_keyword`. One resolution path for every coloured phrase in the header instead of two, reusing the tags `.omni_marquee_style()` registers.

`omni_colors()` is still called, purely to **validate**: an unknown colour name now errors rather than emitting an unregistered tag, which would fail the same silent way the malformed hex did.

## Not reproducible: the case-sensitivity claim

The report also said marquee's inline hex works only in lowercase. It doesn't hold - both forms parse *and* render correctly:

```
{#5776B2 Housing}  -> #5776B2   (uppercase, what omni_colors() returns)
{#5776b2 Housing}  -> #5776b2
```

Only the double hash was wrong. Switching to the class form is still the right fix for the other reasons given, so nothing changes about the patch - but if anything else in the tool is working around a presumed case issue, that workaround isn't needed.

## Tests, and the pattern behind these

The existing `omni_span()` test asserted the hex *appeared in* the output. That passed against `##5776B2`, because it contains `#5776B2` - a substring check structurally cannot catch this.

Replaced with an exact-output assertion plus **parse-level** checks that the colour genuinely resolves, for all three coloured phrases: `omni_span()`, the title keyword, and the finding keyword. Confirmed these fail against the old form (parses to `black`).

That addresses the report's wider observation - four silent marquee-colour bugs this month, none catchable from the theme object. The common thread is that marquee fails soft: a malformed or unregistered tag draws the base colour rather than raising. Parsing the markup with the package's own style is a cheap check that closes the whole class, and is now applied to every path that emits a colour tag.

## Verification

Individual test files all pass (`test_dir()` segfaults intermittently in this environment - confirmed pre-existing by reproducing it on `main` with these changes stashed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)