### PR TITLE
omni_header(): make the measure description a marquee element

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -77,6 +77,16 @@
   this survived review. Third instance of one shape: an element built
   without being fully specified inheriting stale state from `theme_omni()`.
 
+* The measure description (`plot.subtitle`) is now a marquee element rather
+  than a plain `element_text()`. It was the last slot where `omni_header()`
+  and `theme_omni()` disagreed on class - the shape of mismatch that caused
+  theme-merge trouble on the title and caption before those were converted.
+  It also means the measure description **wraps to the plot width**: a long
+  one previously ran off the right edge and clipped, so any script wrapping
+  it by hand can stop. Spacing and colour are unchanged - the margins were
+  re-tuned against rendered output because marquee brings its own line-box
+  leading, which shifted the gaps by 6 and 18 pixels at the old margin.
+
 ## omni_highlight_labels()
 
 * **Breaking:** `color` is now required instead of defaulting to

--- a/R/omni_header.R
+++ b/R/omni_header.R
@@ -88,12 +88,16 @@
 #' that closes it further, and it buys very little (10pt to 9pt is about one pixel at
 #' 150 dpi), so it is not worth trading a brand type size for.
 #'
+#' The measure description wraps to the plot width on its own, so there is no need to insert
+#' line breaks by hand.
+#'
 #' The remaining gaps can be overridden by adding a `theme()` *after* the header, but note
 #' that the visible gap is the margin plus the font's line box, so a margin change does not
 #' translate one-for-one into pixels - check the rendered output rather than trusting the
 #' number. If you override `plot.title`, it must stay a [marquee::element_marquee()] carrying
 #' the title style; replacing it with a plain `element_text()` silently drops the markdown,
-#' so the eyebrow, the colored keyword and the text wrapping all disappear at once.
+#' so the eyebrow, the colored keyword and the text wrapping all disappear at once. The same
+#' applies to `plot.subtitle`, which is also a [marquee::element_marquee()].
 #'
 #' Spacing *inside* the plotting area - how close the category labels sit to the bars, for
 #' instance - is not set here. That is the scale's expansion and the axis text's margin,
@@ -228,7 +232,29 @@ omni_header <- function(
         style = .omni_title_style(primary_size, eyebrow_size, eyebrow_gap),
         margin = ggplot2::margin(t = 8, b = 5.3)
       ),
-      plot.subtitle = ggplot2::element_text(colour = hex_gray, margin = ggplot2::margin(b = 9)),
+      # marquee, not element_text: this was the last slot where omni_header()
+      # and theme_omni() disagreed on class, which is the shape of mismatch
+      # that caused theme-merge trouble on the title and caption before those
+      # were converted. It also gives the measure description real wrapping -
+      # a long one used to run off the right edge and clip.
+      #
+      # colour is set on the element as well as in the style because the
+      # element's colour overrides the style's base (the title bug, #287).
+      # Size is deliberately NOT set: the style's base size has no effect on
+      # this slot - only the element's size does - so leaving it unset keeps
+      # the size the plain element_text inherited, and the measure line
+      # renders exactly as before.
+      #
+      # margin was tuned against rendered output, not assumed: marquee brings
+      # its own line-box leading, so at margin(b = 9) the gaps grew from
+      # 23/52px to 29/70px. t = -1.5, b = 4 restores 23/51px.
+      plot.subtitle = marquee::element_marquee(
+        width = 1,
+        hjust = 0,
+        colour = hex_gray,
+        style = .omni_subtitle_style(),
+        margin = ggplot2::margin(t = -1.5, b = 4)
+      ),
       # style is passed explicitly (not inherited from whatever plot.caption
       # element theme_omni() or the caller left behind) so the {.color ...}
       # class markdown built above always resolves, regardless of theme order.

--- a/R/theme.R
+++ b/R/theme.R
@@ -60,6 +60,34 @@
     )
 }
 
+#' Build the marquee style for the measure description (subtitle)
+#'
+#' [.omni_marquee_style()] with the measure description's typography layered
+#' on top: normal weight, not italic, in the chart gray. Mirrors
+#' [.omni_caption_style()], so each of [omni_header()]'s three slots is built
+#' from a named style helper rather than assembled inline.
+#'
+#' This is [omni_header()]'s subtitle, not [theme_omni()]'s. `theme_omni()`
+#' keeps its own subtitle treatment (larger, darker) for charts that carry a
+#' plain subtitle without the header - matching them would restyle those
+#' charts, which is a separate decision.
+#'
+#' The base carries no bottom margin: a margin there applies to every
+#' paragraph, so it would add space below a wrapped subtitle's last line as
+#' well as between its lines.
+#'
+#' @noRd
+.omni_subtitle_style <- function() {
+  .omni_marquee_style() |>
+    marquee::modify_style(
+      "base",
+      weight = "normal",
+      italic = FALSE,
+      color = omni_colors("chart-gray"),
+      margin = marquee::trbl(0, 0, 0)
+    )
+}
+
 #' OMNI Institute ggplot2 theme
 #'
 #' @description Applies the OMNI Institute theme to the plot.

--- a/man/omni_header.Rd
+++ b/man/omni_header.Rd
@@ -80,12 +80,16 @@ clamped, and line-height has no effect on it. Reducing `eyebrow_size` is the onl
 that closes it further, and it buys very little (10pt to 9pt is about one pixel at
 150 dpi), so it is not worth trading a brand type size for.
 
+The measure description wraps to the plot width on its own, so there is no need to insert
+line breaks by hand.
+
 The remaining gaps can be overridden by adding a `theme()` *after* the header, but note
 that the visible gap is the margin plus the font's line box, so a margin change does not
 translate one-for-one into pixels - check the rendered output rather than trusting the
 number. If you override `plot.title`, it must stay a [marquee::element_marquee()] carrying
 the title style; replacing it with a plain `element_text()` silently drops the markdown,
-so the eyebrow, the colored keyword and the text wrapping all disappear at once.
+so the eyebrow, the colored keyword and the text wrapping all disappear at once. The same
+applies to `plot.subtitle`, which is also a [marquee::element_marquee()].
 
 Spacing *inside* the plotting area - how close the category labels sit to the bars, for
 instance - is not set here. That is the scale's expansion and the axis text's margin,

--- a/tests/testthat/test-omni_header.R
+++ b/tests/testthat/test-omni_header.R
@@ -105,6 +105,23 @@ test_that("omni_header's caption is quieter than the subtitle, not louder", {
   expect_true(base$italic)
 })
 
+test_that("omni_header's subtitle is a marquee element, matching theme_omni's class", {
+  # plot.subtitle was the last slot where the two disagreed on class
+  # (theme_omni marquee vs omni_header element_text). The mismatch is the
+  # shape that caused theme-merge trouble on the title and caption before
+  # those were converted, and it also denied the measure description any
+  # wrapping - a long one ran off the right edge and clipped.
+  h <- omni_header(primary = "x", measure = "What is measured")
+  sub <- h[[2]]$plot.subtitle
+  expect_s3_class(sub, "element_marquee")
+  expect_s3_class(theme_omni()$plot.subtitle, "element_marquee")
+  expect_identical(sub$style, .omni_subtitle_style())
+  expect_equal(sub$hjust, 0)
+  # colour is set on the element too: the element's colour overrides the
+  # style's base, so leaving it NULL would inherit the active theme's
+  expect_identical(sub$colour, unname(omni_colors("chart-gray")))
+})
+
 test_that("theme_omni and omni_header agree on caption styling", {
   # These two set plot.caption independently; they have drifted apart twice
   # (once on color, once on size/weight). Same helper, same result.
@@ -142,7 +159,9 @@ test_that("omni_header gives the eyebrow space above it and the measure space be
   # between the measure description and the panel. Changing them changes the
   # header's rhythm, so they are pinned here deliberately.
   expect_equal(h[[2]]$plot.title$margin, ggplot2::margin(t = 8, b = 5.3))
-  expect_equal(h[[2]]$plot.subtitle$margin, ggplot2::margin(b = 9))
+  # t = -1.5 compensates for the line-box leading marquee brings to this slot;
+  # together with b = 4 it reproduces the spacing the plain element_text had
+  expect_equal(h[[2]]$plot.subtitle$margin, ggplot2::margin(t = -1.5, b = 4))
 })
 
 test_that("omni_header's title sets its own colour rather than inheriting one", {


### PR DESCRIPTION
Closes the last slot where `omni_header()` and `theme_omni()` disagreed on class. Filed as preventive, as reported - nothing was visibly broken - but it turned out to fix a real clipping problem too.

## The class mismatch

`omni_header()` built `plot.subtitle` as a plain `ggplot2::element_text()` while `theme_omni()` uses `marquee::element_marquee()`. That's the same shape of mismatch that caused theme-merge trouble on the title and caption before #276 and #278 converted them.

Adds `.omni_subtitle_style()`, mirroring `.omni_caption_style()`, so each of `omni_header()`'s three slots is now built from a named style helper rather than assembled inline.

`theme_omni()` keeps its own subtitle treatment (larger, darker) for charts that carry a plain subtitle without the header. Matching those would restyle existing charts, which is a separate decision and wasn't asked for.

## It also fixes clipping, not just class hygiene

A long measure description used to run off the right edge and get cut off. It now wraps. Verified at three widths - subtitle right edge at 96% / 94% / 83% of plot width, i.e. inside the plot in every case.

**Any script hand-wrapping the measure line can stop.**

## Both of your cautions were warranted

**Margin translation.** Carrying `margin(b = 9)` over would have been wrong: marquee brings its own line-box leading, so at the same margin the gaps grew from **23/52px to 29/70px**. Measured against the `element_text` baseline and converged on `margin(t = -1.5, b = 4)`, which restores **23/51px**. The negative top margin cancels the leading marquee adds above the first line. Band height (15px) and colour (`#767676`) are unchanged.

**Wrapping at multiple lengths/widths.** Checked as above, plus the short single-line case to confirm no regression when the measure fits on one line.

Two further things surfaced while tuning, both now in comments:

- **The style's base size has no effect on this slot** - only the element's `size` does (verified with style sizes 8 and 24: identical output; element sizes 8 and 18: 11px and 35px). Size is therefore left unset, so it inherits exactly as the `element_text` did and the measure line renders the same. Worth knowing before anyone tries to restyle it via the helper.
- **Colour must be set on the element as well as in the style**, because the element's colour overrides the style's base - the #287 bug.

## Verification

Band height, colour, and both surrounding gaps match the pre-change baseline; wrapping checked at 4.5in / 6.5in / 9in. Test added asserting the class matches `theme_omni()`'s, the shared style is used, `hjust = 0`, and colour is set on the element. All four test files pass.

Note `testthat::test_dir()` segfaults intermittently in this environment - pre-existing, reproduced on `main` with changes stashed - so files were run individually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)