### PR TITLE
Give every marquee header slot a width so long text wraps

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -127,6 +127,16 @@
   rather than erroring, so any hand-written `<span>` in a header needs
   converting.
 
+* The secondary finding (`plot.caption`) now wraps to the plot width, as the
+  title and measure description already did. It was the one marquee slot left
+  without `width`, so a finding longer than the canvas was clipped mid-word
+  instead of breaking - silently. `theme_omni()` was missing the same field on
+  both its subtitle and its caption; all three slots in both functions now set
+  it. Scripts wrapping `finding` by hand can stop, which also removes a
+  failure mode of its own: `finding_keyword` is matched as a fixed string, so
+  a hand-inserted line break landing inside the keyword phrase stopped it
+  matching and dropped the stripe and color.
+
 ## omni_highlight_labels()
 
 * **Breaking:** `color` is now required instead of defaulting to

--- a/R/omni_header.R
+++ b/R/omni_header.R
@@ -88,8 +88,10 @@
 #' that closes it further, and it buys very little (10pt to 9pt is about one pixel at
 #' 150 dpi), so it is not worth trading a brand type size for.
 #'
-#' The measure description wraps to the plot width on its own, so there is no need to insert
-#' line breaks by hand.
+#' The measure description and the secondary finding both wrap to the plot width on their own,
+#' so there is no need to insert line breaks by hand. Doing so can also break `finding_keyword`:
+#' it is matched against `finding` as a fixed string, so a line break falling inside the keyword
+#' phrase stops it matching, and the stripe and color are dropped (with a warning).
 #'
 #' The remaining gaps can be overridden by adding a `theme()` *after* the header, but note
 #' that the visible gap is the margin plus the font's line box, so a margin change does not
@@ -261,7 +263,11 @@ omni_header <- function(
       # It must be the *caption* style, not the shared base: the base is
       # larger and bold, which would render the secondary finding and
       # source/N heavier than the subtitle above them.
+      # width = 1 for the same reason as the title and subtitle: without it a
+      # secondary finding longer than the canvas runs off the right edge and is
+      # clipped mid-word rather than breaking. All three header slots wrap.
       plot.caption = marquee::element_marquee(
+        width = 1,
         hjust = 0,
         colour = hex_gray,
         style = .omni_caption_style()

--- a/R/theme.R
+++ b/R/theme.R
@@ -137,6 +137,7 @@ theme_omni <- function(
       ),
       plot.title.position = "plot",
       plot.subtitle = marquee::element_marquee(
+        width = 1,
         margin = margin(-4, 0, 0, 0),
         style = omni_style |>
           marquee::modify_style(
@@ -153,7 +154,13 @@ theme_omni <- function(
       # omni_header() (which sets hjust = 0) put it bottom-left. Left is the
       # brand standard; both paths now agree regardless of the order they
       # are applied in.
+      # width = 1 on the subtitle and caption as well as the title: these two
+      # were the only marquee slots without it, so long text was clipped at
+      # the canvas edge instead of wrapping. Keeping the field set on all
+      # three also stops this slot pair drifting from omni_header()'s a
+      # fourth time, after color (#267), size/weight (#276) and alignment.
       plot.caption = marquee::element_marquee(
+        width = 1,
         hjust = 0,
         style = .omni_caption_style()
       ),

--- a/man/omni_header.Rd
+++ b/man/omni_header.Rd
@@ -80,8 +80,10 @@ clamped, and line-height has no effect on it. Reducing `eyebrow_size` is the onl
 that closes it further, and it buys very little (10pt to 9pt is about one pixel at
 150 dpi), so it is not worth trading a brand type size for.
 
-The measure description wraps to the plot width on its own, so there is no need to insert
-line breaks by hand.
+The measure description and the secondary finding both wrap to the plot width on their own,
+so there is no need to insert line breaks by hand. Doing so can also break `finding_keyword`:
+it is matched against `finding` as a fixed string, so a line break falling inside the keyword
+phrase stops it matching, and the stripe and color are dropped (with a warning).
 
 The remaining gaps can be overridden by adding a `theme()` *after* the header, but note
 that the visible gap is the margin plus the font's line box, so a margin change does not

--- a/tests/testthat/test-omni_header.R
+++ b/tests/testthat/test-omni_header.R
@@ -164,6 +164,24 @@ test_that("omni_header's subtitle is a marquee element, matching theme_omni's cl
   expect_identical(sub$colour, unname(omni_colors("chart-gray")))
 })
 
+test_that("every marquee header slot wraps, in both functions", {
+  # A slot with no `width` does not wrap: long text runs off the canvas and is
+  # clipped mid-word, silently. plot.caption was the last one missing it, and
+  # theme_omni() was missing it on the subtitle too. Asserting all six keeps
+  # this field from drifting the way color (#267), size/weight (#276) and
+  # alignment already did.
+  slots <- c("plot.title", "plot.subtitle", "plot.caption")
+
+  hdr <- ggplot2::ggplot(mtcars, ggplot2::aes(wt, mpg)) +
+    ggplot2::geom_point() +
+    omni_header(primary = "P", measure = "M", finding = "F", finding_keyword = "F")
+  resolved <- ggplot2::ggplot_build(hdr)$plot$theme
+  for (sl in slots) expect_equal(resolved[[sl]]$width, 1, info = sl)
+
+  th <- theme_omni()
+  for (sl in slots) expect_equal(th[[sl]]$width, 1, info = sl)
+})
+
 test_that("theme_omni and omni_header agree on caption styling", {
   # These two set plot.caption independently; they have drifted apart twice
   # (once on color, once on size/weight). Same helper, same result.


### PR DESCRIPTION
Confirmed as reported, and the scope is slightly wider than the report assumed.

## The gap

`plot.caption` was the one marquee slot in `omni_header()` with no `width`, so a secondary finding longer than the canvas ran off the right edge and was **clipped mid-word** rather than breaking. Silent - no error, no warning.

Measured caption ink reach across three canvas widths:

| | before | after |
|---|---|---|
| 5 in | 100% (clipped) | 91% |
| 6 in | 100% (clipped) | 96% |
| 9 in | 100% (clipped) | 93% |

`finding_keyword`'s stripe and colour survive the wrap - constant 268 coloured pixels at every width.

## `theme_omni()` was missing it on two slots, not one

The report suggested checking `theme_omni()`. Worth it - it was missing `width` on **both** its subtitle and its caption:

| | `theme_omni()` before | `omni_header()` before |
|---|---|---|
| `plot.title` | 1 | 1 |
| `plot.subtitle` | **NULL** | 1 (since #295) |
| `plot.caption` | **NULL** | **NULL** |

So charts using `theme_omni()` without the header clipped too. All three slots in both functions now set `width = 1`.

**Behaviour note:** a long subtitle or caption on a `theme_omni()`-only chart now wraps rather than clipping, which makes the plot panel slightly shorter. That's a visible change to existing figures - but the previous behaviour was cutting text off, so it's a correction rather than a preference.

## Test pins all six

`width` is the *fourth* field these two functions have disagreed on for the same slot, after colour (#267), size/weight (#276) and alignment. The test asserts it on all six slots rather than fixing this one case, so a fifth drift fails loudly.

## The keyword knock-on, confirmed

Their secondary point checks out. `finding_keyword` is matched against `finding` as a fixed string, so a hand-inserted line break landing inside the keyword phrase stops it matching and drops the stripe and colour:

```
no break               -> coloured
break inside keyword   -> NOT coloured   (warning: 'Behavioral Health' not found; left uncolored)
break elsewhere        -> coloured
```

One correction to the framing: this one **does warn**, so unlike the clipping it was never silent. I've left `.wrap_first()` as is - the warning is the right behaviour, and the root cause disappears once the caption wraps itself. **The hand-wrapping helper can be dropped.**

Documented in `?omni_header` that both the measure description and the secondary finding wrap on their own, and that hand-inserted breaks can break `finding_keyword`.

## Verification

All four test files pass. (`testthat::test_dir()` segfaults intermittently in this environment - pre-existing, reproduced on `main` with changes stashed - so files were run individually.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)