### PR TITLE
omni_header(): document that it clears both axis titles

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -136,6 +136,14 @@
   failure mode of its own: `finding_keyword` is matched as a fixed string, so
   a hand-inserted line break landing inside the keyword phrase stopped it
   matching and dropped the stripe and color.
+* Documented that `omni_header()` clears both axis titles. It sets
+  `labs(x = NULL, y = NULL)` - the brand standard drops axis titles and the
+  measure description carries what is being measured - so a `labs()` call
+  placed *before* the header was discarded with no error and no warning. The
+  help page now says so and shows the working order (`labs()` after the
+  header), for the charts that do need one, such as a count axis on a
+  histogram. Behaviour is unchanged; this was previously recorded only in a
+  source comment.
 
 ## omni_highlight_labels()
 

--- a/R/omni_header.R
+++ b/R/omni_header.R
@@ -106,6 +106,22 @@
 #' which belong to the chart code and [theme_omni()]; `omni_header()` is text-only and
 #' geometry-agnostic by design.
 #'
+#' @section Axis titles:
+#' Both axis titles are cleared (\code{labs(x = NULL, y = NULL)}). The brand standard drops
+#' them and the measure description carries what is being measured, so this is what most
+#' charts want.
+#'
+#' It does mean a \code{labs()} call placed \emph{before} the header is discarded, with no
+#' error and no warning:
+#'
+#' \preformatted{
+#' p + labs(y = "Students") + omni_header(...)   # dropped
+#' p + omni_header(...) + labs(y = "Students")   # kept
+#' }
+#'
+#' Put the \code{labs()} after the header on the charts that do need an axis title - a count
+#' axis on a histogram, for instance, which the measure description does not describe.
+#'
 #' @param primary Required. The finding, written as a sentence.
 #' @param keyword Substring of `primary` to color (first occurrence). `NULL` = all navy.
 #' @param top_header Eyebrow line, e.g. `"PROGRAM REACH - FY2024"`. `NULL` = no eyebrow.

--- a/man/omni_header.Rd
+++ b/man/omni_header.Rd
@@ -99,6 +99,24 @@ which belong to the chart code and [theme_omni()]; `omni_header()` is text-only 
 geometry-agnostic by design.
 }
 
+\section{Axis titles}{
+
+Both axis titles are cleared (\code{labs(x = NULL, y = NULL)}). The brand standard drops
+them and the measure description carries what is being measured, so this is what most
+charts want.
+
+It does mean a \code{labs()} call placed \emph{before} the header is discarded, with no
+error and no warning:
+
+\preformatted{
+p + labs(y = "Students") + omni_header(...)   # dropped
+p + omni_header(...) + labs(y = "Students")   # kept
+}
+
+Put the \code{labs()} after the header on the charts that do need an axis title - a count
+axis on a histogram, for instance, which the measure description does not describe.
+}
+
 \examples{
 library(ggplot2)
 ggplot(mtcars, aes(wt, mpg)) +


### PR DESCRIPTION
Docs only. No behaviour change.

## The gap

`omni_header()` sets `labs(x = NULL, y = NULL)`, by design: the brand standard drops axis titles, and the measure description carries what is being measured. Most charts want this.

The consequence was undocumented. A `labs()` call placed *before* the header is discarded, with no error and no warning:

```r
p + labs(y = "Students") + omni_header(...)   # dropped
p + omni_header(...) + labs(y = "Students")   # kept
```

This was recorded only in a source comment at `R/omni_header.R:201`. It is not in `?omni_header`, so anyone reading the help page, or any tool writing the call from it, hits it blind. Found while building a histogram companion figure, where the count axis is a legitimate case for a `y` title that the measure description does not describe. It cost a render to spot.

## The fix

Adds an `@section Axis titles:` block giving the reason, both orders, and the case where an axis title is genuinely wanted.

## Rd markup, not markdown

Written with `\code{}` / `\emph{}` / `\preformatted{}` rather than backticks and fences, because **this package has no `Roxygen: list(markdown = TRUE)` in DESCRIPTION**. Confirmed empirically: `[omni_baseline()]` in this file's existing roxygen lands in `man/omni_header.Rd` literally rather than as a `\link`. `R/table.R` is the correct model and is what I followed.

Worth flagging separately: the rest of `R/omni_header.R`'s roxygen is written in markdown style that currently does not render. Out of scope here, but it is a real (cosmetic) issue across that file.

## Verification

- `tools::checkRd()` reports the same single pre-existing note on this branch as on `main` (byte-identical: the `{.plum-600 Housing}` marquee example at line 63). Nothing new introduced.
- Rendered with `tools::Rd2txt()` to confirm the section, the emphasis, and the `\preformatted` block all come out intact.
- `DESCRIPTION` deliberately left untouched. Local roxygen is 7.3.3 and the repo pins `Config/roxygen2/version: 8.0.0`, so the `RoxygenNote: 7.3.3` line `document()` wanted to add was reverted. The regenerated `.Rd` is otherwise churn-free, which confirms 7.3.3 and 8.0.0 agree on the rest of this file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)