### PR TITLE
Default eyebrow_size to 11pt, the brand floor

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -162,6 +162,17 @@
   the caption's 8.8 to 11pt jump is large enough to reflow wrapping. This is
   a correction toward the brand standard rather than a preference, but it is
   visible and will shift layouts.
+* `eyebrow_size` now defaults to 11pt rather than 10. Not a bug fix;
+  `eyebrow_size` always worked. The eyebrow was the only element sitting
+  below the brand's 11pt floor for figure text, and it is the one element
+  that can least afford it: it is the only ALL CAPS text on a chart, and
+  uppercase removes the ascender and descender cues readers use to
+  recognise word shapes, so it needs more size than mixed case for equal
+  legibility. Measuring the training template agrees - anchoring the source
+  note at 11pt puts its eyebrow near 11.8pt. This is a legibility and
+  hierarchy judgement, not a contrast fix: at both 10 and 11pt bold the
+  eyebrow is below the WCAG large-text cutoff, so chart-gray is held to
+  4.5:1 either way, and it passes at 4.54:1 before and after.
 
 ## omni_highlight_labels()
 

--- a/R/omni_header.R
+++ b/R/omni_header.R
@@ -131,7 +131,11 @@
 #' @param source Data source; rendered as `"Source: <source>."`.
 #' @param n Sample size; rendered as `"N = <n>."`.
 #' @param color The chart's one highlight color name (title keyword + finding keyword/stripe).
-#' @param primary_size,eyebrow_size Font sizes in pt.
+#' @param primary_size,eyebrow_size Font sizes in pt. The eyebrow defaults to 11, the
+#'   smallest size the brand allows in a figure. It is set at the floor rather than
+#'   below it because it is the only ALL CAPS element on the chart, and uppercase
+#'   removes the ascender and descender cues readers use to recognise word shapes,
+#'   so it needs more size than mixed-case text for equal legibility.
 #' @param eyebrow_gap Extra space between the eyebrow and the primary finding, in `rem`.
 #'   Only applies when `top_header` is given. `0` (the default) is as tight as the two lines
 #'   go - the residual gap at `0` is the fonts' own line boxes, which no margin can shrink.
@@ -163,7 +167,7 @@ omni_header <- function(
   n = NULL,
   color = "orange-red-600",
   primary_size = 18,
-  eyebrow_size = 10,
+  eyebrow_size = 11,
   eyebrow_gap = 0
 ) {
   hex_gray <- omni_colors("chart-gray")

--- a/man/omni_header.Rd
+++ b/man/omni_header.Rd
@@ -15,7 +15,7 @@ omni_header(
   n = NULL,
   color = "orange-red-600",
   primary_size = 18,
-  eyebrow_size = 10,
+  eyebrow_size = 11,
   eyebrow_gap = 0
 )
 }
@@ -38,7 +38,11 @@ omni_header(
 
 \item{color}{The chart's one highlight color name (title keyword + finding keyword/stripe).}
 
-\item{primary_size, eyebrow_size}{Font sizes in pt.}
+\item{primary_size, eyebrow_size}{Font sizes in pt. The eyebrow defaults to 11, the
+smallest size the brand allows in a figure. It is set at the floor rather than
+below it because it is the only ALL CAPS element on the chart, and uppercase
+removes the ascender and descender cues readers use to recognise word shapes,
+so it needs more size than mixed-case text for equal legibility.}
 
 \item{eyebrow_gap}{Extra space between the eyebrow and the primary finding, in `rem`.
 Only applies when `top_header` is given. `0` (the default) is as tight as the two lines

--- a/tests/testthat/test-omni_header.R
+++ b/tests/testthat/test-omni_header.R
@@ -217,6 +217,22 @@ test_that("every marquee header slot sets size on the element, not only the styl
   expect_equal(ggplot2::calc_element("plot.caption", th2)$size, 11)
 })
 
+test_that("the eyebrow defaults to 11pt, the brand floor", {
+  # The eyebrow is the smallest and the only ALL CAPS element, so it sits AT
+  # the floor rather than below it: uppercase drops the ascender/descender
+  # cues readers use for word shape, so it needs more size than mixed case for
+  # equal legibility. Measuring the training template agrees - anchoring the
+  # source note at 11pt puts the eyebrow near 11.8pt, so 10 was below both the
+  # floor and the template.
+  h <- omni_header(primary = "P", top_header = "EYEBROW")
+  st <- unclass(h[[2]]$plot.title$style)[[1]]
+  expect_equal(st$h1$size, 11)
+
+  # and it still responds to the argument
+  h16 <- omni_header(primary = "P", top_header = "EYEBROW", eyebrow_size = 16)
+  expect_equal(unclass(h16[[2]]$plot.title$style)[[1]]$h1$size, 16)
+})
+
 test_that("primary_size actually changes the title size", {
   # The regression this guards is specific: primary_size reached the style but
   # not the element, so it was inert. Assert it reaches the element.


### PR DESCRIPTION
Deliberate default change, not a bug fix. Confirmed `eyebrow_size` already works: rendered cap band gives **10 -> 9.9pt, 11 -> 10.9pt, 12 -> 12.2pt**.

## Why

The eyebrow was the only element below the brand's 11pt floor for figure text, and it is the element that can least afford it. It is the only ALL CAPS text on a chart, and uppercase removes the ascender and descender cues readers use to recognise word shapes, so it needs more size than mixed case for equal legibility.

## The training template agrees

I had set the eyebrow aside when measuring the template earlier, on the grounds that ALL CAPS is not comparable to mixed case. With the real font metrics it is comparable, because ALL CAPS with no descenders means the ink band **is** cap height directly.

Inter Tight, read from the font: cap height **0.728 em**, x-height **0.546 em**.

| | measured | -> em | -> pt |
|---|---|---|---|
| Source note (mixed case) | 7px x-height | 12.82px | 11 (anchor) |
| Eyebrow (ALL CAPS) | 10px cap band | 13.74px | **~11.8** |

So 10pt was below both the floor and the template. 11 is the conservative read of a measurement that centres nearer 12.

## Not a contrast fix

At 10 and 11pt bold alike the eyebrow is below the WCAG large-text cutoff (14pt+ bold), so chart-gray is held to 4.5:1 either way. It passes at **4.54:1** before and after. This is legibility and hierarchy, not accessibility.

## On the collapsed ladder

The suggestion noted this puts the eyebrow and caption both at 11pt. Worth doing anyway, for two reasons.

Size is not the only differentiator here: the eyebrow is ALL CAPS bold, the caption is italic regular, and they sit at opposite ends of the figure and never appear adjacent.

More to the point, the template has the eyebrow *larger* than the source note (11.8 vs 11). The current 10/11 inverts that relationship. Making them equal moves toward the template rather than away from it. Raising the caption to 12 to preserve a gap would move both further from it.

## Verification

All 61 tests in `test-omni_header.R` pass, including a new one pinning the default and confirming the argument still overrides it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)